### PR TITLE
新增 BetCakeFarm 、 TempStakeManagerCakeFarm 合約及測試

### DIFF
--- a/contracts/BaseSingleTokenStaking.sol
+++ b/contracts/BaseSingleTokenStaking.sol
@@ -36,6 +36,10 @@ abstract contract BaseSingleTokenStaking is ReentrancyGuard, Pausable, UUPSUpgra
     uint256 internal _totalSupply;
     mapping(address => uint256) internal _balances;
 
+    /* ========== FALLBACKS ========== */
+
+    receive() external payable {}
+
     /* ========== VIEWS ========== */
 
     /// @dev Get the implementation contract of this proxy contract.
@@ -56,8 +60,6 @@ abstract contract BaseSingleTokenStaking is ReentrancyGuard, Pausable, UUPSUpgra
     function earned(address account) public virtual view returns (uint256) {}
 
     /* ========== MUTATIVE FUNCTIONS ========== */
-
-    receive() external payable {}
 
     function _convertAndAddLiquidity(
         bool isToken0,

--- a/contracts/cake_farm/BaseSingleTokenStakingCakeFarm.sol
+++ b/contracts/cake_farm/BaseSingleTokenStakingCakeFarm.sol
@@ -42,6 +42,10 @@ abstract contract BaseSingleTokenStakingCakeFarm is ReentrancyGuard, Pausable, U
 
     mapping(address => UserInfo) public userInfo;
 
+    /* ========== FALLBACKS ========== */
+
+    receive() external payable {}
+
     /* ========== VIEWS ========== */
 
     /// @dev Get the implementation contract of this proxy contract.

--- a/contracts/cake_farm/BaseSingleTokenStakingCakeFarm.sol
+++ b/contracts/cake_farm/BaseSingleTokenStakingCakeFarm.sol
@@ -146,6 +146,16 @@ abstract contract BaseSingleTokenStakingCakeFarm is ReentrancyGuard, Pausable, U
         }
     }
 
+    function _stake(address staker, uint256 lpAmount) internal virtual {
+        lp.safeApprove(address(masterChef), lpAmount);
+        masterChef.deposit(pid, lpAmount);
+
+        // Top up staker's balance
+        userInfo[address(this)].amount = userInfo[address(this)].amount + lpAmount;
+        userInfo[staker].amount = userInfo[staker].amount + lpAmount;
+        emit Staked(staker, lpAmount);
+    }
+
     /// @notice Taken token0 or token1 in, convert half to the other token, provide liquidity and stake
     /// the LP tokens into MasterChef contract. Leftover token0 or token1 will be returned to msg.sender.
     /// @param isToken0 Determine if token0 is the token msg.sender going to use for staking, token1 otherwise
@@ -161,26 +171,14 @@ abstract contract BaseSingleTokenStakingCakeFarm is ReentrancyGuard, Pausable, U
         uint256 minToken1AmountAddLiq
     ) public virtual nonReentrant notPaused updateReward(msg.sender) {
         uint256 lpAmount = _convertAndAddLiquidity(isToken0, true, amount, minReceivedTokenAmountSwap, minToken0AmountAddLiq, minToken1AmountAddLiq);
-        lp.safeApprove(address(masterChef), lpAmount);
-        masterChef.deposit(pid, lpAmount);
-
-        // Top up msg.sender's balance
-        userInfo[address(this)].amount = userInfo[address(this)].amount + lpAmount;
-        userInfo[msg.sender].amount = userInfo[msg.sender].amount + lpAmount;
-        emit Staked(msg.sender, lpAmount);
+        _stake(msg.sender, lpAmount);
     }
 
     /// @notice Take LP tokens and stake into MasterChef contract.
     /// @param lpAmount Amount of LP tokens to stake
-    function stakeWithLP(uint256 lpAmount) public nonReentrant notPaused updateReward(msg.sender) {
+    function stakeWithLP(uint256 lpAmount) public virtual nonReentrant notPaused updateReward(msg.sender) {
         lp.safeTransferFrom(msg.sender, address(this), lpAmount);
-        lp.safeApprove(address(masterChef), lpAmount);
-        masterChef.deposit(pid, lpAmount);
-
-        // Top up msg.sender's balance
-        userInfo[address(this)].amount = userInfo[address(this)].amount + lpAmount;
-        userInfo[msg.sender].amount = userInfo[msg.sender].amount + lpAmount;
-        emit Staked(msg.sender, lpAmount);
+        _stake(msg.sender, lpAmount);
     }
 
     function _validateIsNativeToken() internal view returns (address, bool) {
@@ -204,13 +202,7 @@ abstract contract BaseSingleTokenStakingCakeFarm is ReentrancyGuard, Pausable, U
 
         IWETH(NATIVE_TOKEN).deposit{ value: msg.value }();
         uint256 lpAmount = _convertAndAddLiquidity(isToken0, false, msg.value, minReceivedTokenAmountSwap, minToken0AmountAddLiq, minToken1AmountAddLiq);
-        lp.safeApprove(address(masterChef), lpAmount);
-        masterChef.deposit(pid, lpAmount);
-
-        // Top up msg.sender's balance
-        userInfo[address(this)].amount = userInfo[address(this)].amount + lpAmount;
-        userInfo[msg.sender].amount = userInfo[msg.sender].amount + lpAmount;
-        emit Staked(msg.sender, lpAmount);
+        _stake(msg.sender, lpAmount);
     }
 
     /// @notice Withdraw stake from StakingRewards, remove liquidity and convert one asset to another.
@@ -218,17 +210,83 @@ abstract contract BaseSingleTokenStakingCakeFarm is ReentrancyGuard, Pausable, U
     /// @param minToken1AmountConverted The minimum amount of token1 received when removing liquidity
     /// @param token0Percentage Determine what percentage of token0 to return to user. Any number between 0 to 100
     /// @param amount Amount of stake to withdraw
-    function withdraw(uint256 minToken0AmountConverted, uint256 minToken1AmountConverted, uint256 token0Percentage, uint256 amount) public virtual nonReentrant updateReward(msg.sender) {}
+    function withdraw(uint256 minToken0AmountConverted, uint256 minToken1AmountConverted, uint256 token0Percentage, uint256 amount) public virtual nonReentrant updateReward(msg.sender) {
+        require(amount > 0, "Cannot withdraw 0");
+
+        // Update records:
+        // substract withdrawing LP amount from total LP amount staked
+        userInfo[address(this)].amount = (userInfo[address(this)].amount - amount);
+        // substract withdrawing LP amount from user's balance
+        userInfo[msg.sender].amount = (userInfo[msg.sender].amount - amount);
+
+        // Withdraw from Master Chef
+        masterChef.withdraw(pid, amount);
+
+        lp.safeApprove(address(converter), amount);
+        converter.removeLiquidityAndConvert(
+            IPancakePair(address(lp)),
+            amount,
+            minToken0AmountConverted,
+            minToken1AmountConverted,
+            token0Percentage,
+            msg.sender
+        );
+
+        emit Withdrawn(msg.sender, amount);
+    }
 
     /// @notice Withdraw LP tokens from MasterChef and return to user.
     /// @param lpAmount Amount of LP tokens to withdraw
-    function withdrawWithLP(uint256 lpAmount) public virtual nonReentrant notPaused updateReward(msg.sender) {}
+    function withdrawWithLP(uint256 lpAmount) public virtual nonReentrant notPaused updateReward(msg.sender) {
+        require(lpAmount > 0, "Cannot withdraw 0");
+
+        // Update records:
+        // substract withdrawing LP amount from total LP amount staked
+        userInfo[address(this)].amount = (userInfo[address(this)].amount - lpAmount);
+        // substract withdrawing LP amount from user's balance
+        userInfo[msg.sender].amount = (userInfo[msg.sender].amount - lpAmount);
+
+        // Withdraw from Master Chef
+        masterChef.withdraw(pid, lpAmount);
+        lp.safeTransfer(msg.sender, lpAmount);
+
+        emit Withdrawn(msg.sender, lpAmount);
+    }
 
     /// @notice Withdraw stake from StakingRewards, remove liquidity and convert one asset to another.
     /// @param minToken0AmountConverted The minimum amount of token0 received when removing liquidity
     /// @param minToken1AmountConverted The minimum amount of token1 received when removing liquidity
     /// @param amount Amount of stake to withdraw
-    function withdrawWithNative(uint256 minToken0AmountConverted, uint256 minToken1AmountConverted, uint256 amount) public virtual nonReentrant notPaused updateReward(msg.sender) {}
+    function withdrawWithNative(uint256 minToken0AmountConverted, uint256 minToken1AmountConverted, uint256 amount) public virtual nonReentrant notPaused updateReward(msg.sender) {
+        require(amount > 0, "Cannot withdraw 0");
+        (address NATIVE_TOKEN, bool isToken0) = _validateIsNativeToken();
+
+        // Update records:
+        // substract withdrawing LP amount from total LP amount staked
+        userInfo[address(this)].amount = (userInfo[address(this)].amount - amount);
+        // substract withdrawing LP amount from user's balance
+        userInfo[msg.sender].amount = (userInfo[msg.sender].amount - amount);
+
+        // Withdraw from Master Chef
+        masterChef.withdraw(pid, amount);
+
+        uint256 balBefore = IERC20(NATIVE_TOKEN).balanceOf(address(this));
+        lp.safeApprove(address(converter), amount);
+        converter.removeLiquidityAndConvert(
+            IPancakePair(address(lp)),
+            amount,
+            minToken0AmountConverted,
+            minToken1AmountConverted,
+            isToken0 ? 100 : 0,
+            address(this)
+        );
+        uint256 balAfter = IERC20(NATIVE_TOKEN).balanceOf(address(this));
+        // Withdraw native token and send to user
+        IWETH(NATIVE_TOKEN).withdraw(balAfter - balBefore);
+        payable(msg.sender).transfer(balAfter - balBefore);
+
+        emit Withdrawn(msg.sender, amount);
+    }
 
     /// @notice Get the reward out and convert one asset to another.
     function getReward(uint256 minToken0AmountConverted, uint256 minToken1AmountConverted, uint256 minBCNTAmountConverted) public virtual nonReentrant updateReward(msg.sender) {}
@@ -258,7 +316,7 @@ abstract contract BaseSingleTokenStakingCakeFarm is ReentrancyGuard, Pausable, U
 
     /* ========== MODIFIERS ========== */
 
-    modifier updateReward(address account) virtual {
+    function _updateRewardBefore(address account) internal {
         masterChef.updatePool(pid);
         uint256 accCakePerShare = _getAccCakePerShare();
         UserInfo storage user = userInfo[account];
@@ -270,8 +328,12 @@ abstract contract BaseSingleTokenStakingCakeFarm is ReentrancyGuard, Pausable, U
             uint256 totalPending = total.amount * accCakePerShare / 1e12 - total.rewardDebt;
             total.accruedReward = total.accruedReward + totalPending;
         }
+    }
 
-        _;
+    function _updateRewardAfter(address account) internal {
+        uint256 accCakePerShare = _getAccCakePerShare();
+        UserInfo storage user = userInfo[account];
+        UserInfo storage total = userInfo[address(this)];
 
         if (account != address(0)) {
             user.rewardDebt = user.amount * accCakePerShare / 1e12;
@@ -279,8 +341,15 @@ abstract contract BaseSingleTokenStakingCakeFarm is ReentrancyGuard, Pausable, U
         }
     }
 
+    modifier updateReward(address account) virtual {
+        _updateRewardBefore(account);
+        _;
+        _updateRewardAfter(account);
+    }
+
     /* ========== EVENTS ========== */
 
     event Staked(address indexed user, uint256 amount);
+    event Withdrawn(address indexed user, uint256 amount);
     event Recovered(address token, uint256 amount);
 }

--- a/contracts/cake_farm/BetCakeFarm.sol
+++ b/contracts/cake_farm/BetCakeFarm.sol
@@ -1,0 +1,227 @@
+pragma solidity ^0.8.0;
+
+import "./BaseSingleTokenStakingCakeFarm.sol";
+import "../interfaces/IStakingRewards.sol";
+
+/// @title A wrapper contract over MasterChef contract that allows single asset in/out,
+/// with operator periodically investing accrued rewards and return them with profits.
+/// Contract has two states, Fund state and Lock state:
+///     - During Fund state, everything is normal.
+///     - During Lock state, there are some special rules applied when user wants to `stake` and `getReward`.
+/// - When operator invests accrued rewards, the contract enters Lock state.
+///     - During Lock state, new stake will be transferred to TempStakeManager contract and accrue rewards there.
+///     - Operator need to transfer users' stake from TempStakeManager contract after contract enters Fund state.
+///     - If user `getReward` during Lock state, a penalty will be applied. User will not get all rewards he earned.
+/// - When operator returns rewards, the contract enters Fund state.
+/// @notice Asset tokens are token0 and token1. Staking token is the LP token of token0/token1.
+/// User will be earning returned rewards.
+contract BetCakeFarm is BaseSingleTokenStakingCakeFarm {
+    using SafeERC20 for IERC20;
+
+    struct BalanceDiff {
+        uint256 balBefore;
+        uint256 balAfter;
+        uint256 balDiff;
+    }
+
+    struct minAmountVars {
+        uint256 cakeToStakingTokenSwap;
+        uint256 rewardToToken0Swap;
+        uint256 tokenInToTokenOutSwap;
+        uint256 tokenInAddLiq;
+        uint256 tokenOutAddLiq;
+    }
+
+    /* ========== STATE VARIABLES ========== */
+
+    address public operator;
+
+    /* ========== CONSTRUCTOR ========== */
+
+    function initialize(
+        string memory _name,
+        address _owner,
+        address _operator,
+        address _BCNT,
+        IERC20 _cake,
+        uint256 _pid,
+        IPancakePair _lp,
+        IConverter _converter,
+        address _masterChef,
+        IStakingRewards _stakingRewards
+    ) external {
+        require(keccak256(abi.encodePacked(name)) == keccak256(abi.encodePacked("")), "Already initialized");
+        super.initializePausable(_owner);
+        super.initializeReentrancyGuard();
+
+        name = _name;
+        operator = _operator;
+        BCNT = _BCNT;
+        cake = _cake;
+        pid = _pid;
+        lp = IERC20(address(_lp));
+        token0 = IERC20(_lp.token0());
+        token1 = IERC20(_lp.token1());
+        converter = _converter;
+        masterChef = IMasterChef(_masterChef);
+        stakingRewards = _stakingRewards;
+        stakingRewardsStakingToken = IERC20(stakingRewards.stakingToken());
+        stakingRewardsRewardsToken = IERC20(stakingRewards.rewardsToken());
+
+        (address _poolLP, , ,) = masterChef.poolInfo(_pid);
+        require(_poolLP == address(_lp), "Wrong LP token");
+    }
+
+    /* ========== VIEWS ========== */
+
+    receive() external payable {}
+
+    /// @notice Get the reward share earned by specified account.
+    function _share(address account) public view returns (uint256) {
+        UserInfo memory user = userInfo[account];
+
+        uint256 totalAllocPoint = masterChef.totalAllocPoint();
+        uint256 cakePerBlock = masterChef.cakePerBlock();
+        (, uint256 allocPoint, uint256 lastRewardBlock, uint256 accCakePerShare) = masterChef.poolInfo(pid);
+        uint256 lpSupply = lp.balanceOf(address(masterChef));
+        if (block.number > lastRewardBlock && lpSupply != 0) {
+            uint256 multiplier = masterChef.getMultiplier(lastRewardBlock, block.number);
+            uint256 cakeReward = (multiplier * cakePerBlock * allocPoint) / totalAllocPoint;
+            accCakePerShare = accCakePerShare + ((cakeReward * 1e12) / lpSupply);
+        }
+        return user.amount * accCakePerShare / 1e12 - user.rewardDebt + user.accruedReward;
+    }
+
+    /// @notice Get the total reward share in this contract.
+    /// @notice Total reward is tracked with `_rewards[address(this)]` and `_userRewardPerTokenPaid[address(this)]`
+    function _shareTotal() public view returns (uint256) {
+        return _share(address(this));
+    }
+
+    /// @notice Get the compounded LP amount earned by specified account.
+    function earned(address account) public override view returns (uint256) {
+
+    }
+
+    /* ========== MUTATIVE FUNCTIONS ========== */
+
+    /// @inheritdoc BaseSingleTokenStakingCakeFarm
+    function withdraw(
+        uint256 minToken0AmountConverted,
+        uint256 minToken1AmountConverted,
+        uint256 token0Percentage,
+        uint256 amount
+    ) public override nonReentrant updateReward(msg.sender) {
+
+    }
+
+    /// @inheritdoc BaseSingleTokenStakingCakeFarm
+    function withdrawWithLP(uint256 lpAmount) public override nonReentrant notPaused updateReward(msg.sender) {
+
+    }
+
+    /// @inheritdoc BaseSingleTokenStakingCakeFarm
+    function withdrawWithNative(uint256 minToken0AmountConverted, uint256 minToken1AmountConverted, uint256 amount) public override nonReentrant notPaused updateReward(msg.sender) {
+
+    }
+
+    /// @notice Get the reward out and convert one asset to another. Note that reward is LP token.
+    /// @param minToken0AmountConverted The minimum amount of token0 received when removing liquidity
+    /// @param minToken1AmountConverted The minimum amount of token1 received when removing liquidity
+    /// @param minBCNTAmountConverted The minimum amount of BCNT received swapping token0 for BCNT
+    function getReward(
+        uint256 minToken0AmountConverted,
+        uint256 minToken1AmountConverted,
+        uint256 minBCNTAmountConverted
+    ) public override updateReward(msg.sender) {
+
+    }
+
+    /// @notice Withdraw all stake from StakingRewards, remove liquidity, get the reward out and convert one asset to another.
+    /// @param minToken0AmountConverted The minimum amount of token0 received when removing liquidity
+    /// @param minToken1AmountConverted The minimum amount of token1 received when removing liquidity
+    /// @param minBCNTAmountConverted The minimum amount of BCNT received swapping token0 for BCNT
+    /// @param token0Percentage Determine what percentage of token0 to return to user. Any number between 0 to 100
+    function exit(uint256 minToken0AmountConverted, uint256 minToken1AmountConverted, uint256 minBCNTAmountConverted, uint256 token0Percentage) external override {
+        withdraw(minToken0AmountConverted, minToken1AmountConverted, token0Percentage, userInfo[msg.sender].amount);
+        getReward(minToken0AmountConverted, minToken1AmountConverted, minBCNTAmountConverted);
+    }
+
+    /// @notice Withdraw all stake from StakingRewards, remove liquidity, get the reward out and convert one asset to another.
+    /// @param minToken0AmountConverted The minimum amount of token0 received when removing liquidity
+    /// @param minToken1AmountConverted The minimum amount of token1 received when removing liquidity
+    /// @param minBCNTAmountConverted The minimum amount of BCNT received swapping token0 for BCNT
+    function exitWithLP(uint256 minToken0AmountConverted, uint256 minToken1AmountConverted, uint256 minBCNTAmountConverted) external override {
+        withdrawWithLP(userInfo[msg.sender].amount);
+        getReward(minToken0AmountConverted, minToken1AmountConverted, minBCNTAmountConverted);
+    }
+
+    /// @inheritdoc BaseSingleTokenStakingCakeFarm
+    function exitWithNative(uint256 token0Percentage, uint256 minToken0AmountConverted, uint256 minToken1AmountConverted, uint256 minTokenAmountConverted) external override {
+        withdrawWithNative(minToken0AmountConverted, minToken1AmountConverted, userInfo[msg.sender].amount);
+        getReward(minToken0AmountConverted, minToken1AmountConverted, minTokenAmountConverted);
+    }
+
+    function _convertCakeToStakingToken(uint256 cakeLeft, minAmountVars memory minAmounts) internal {
+
+    }
+
+    /// @notice compound is split into two parts but pipelined, both part will be exectued each time:
+    /// First part: get all Cake out from MasterChef contract, convert all to staking token of StakingRewards contract
+    /// Second part: get all rewards out from StakingReward, convert rewards to both token0 and token1 and provide liquidity and stake
+    /// the LP tokens back into MasterChef contract.
+    /// @dev LP tokens staked this way will be tracked in `lpAmountCompounded`.
+    /// @param minAmounts The minimum amounts of
+    /// 1. stakingRewardsStakingToken expected to receive when swapping Cake for stakingRewardsStakingToken
+    /// 2. token0 expected to receive when swapping stakingRewardsRewardsToken for token0
+    /// 3. tokenOut expected to receive when swapping inToken for outToken
+    /// 4. tokenIn expected to add when adding liquidity
+    /// 5. tokenOut expected to add when adding liquidity
+    function compound(
+        minAmountVars memory minAmounts
+    ) external nonReentrant updateReward(address(0)) onlyOperator {
+
+    }
+
+    function updateOperator(address newOperator) external onlyOwner {
+        operator = newOperator;
+
+        emit UpdateOperator(newOperator);
+    }
+
+    /* ========== MODIFIERS ========== */
+
+    modifier updateReward(address account) override {
+        masterChef.updatePool(pid);
+        uint256 accCakePerShare = _getAccCakePerShare();
+        UserInfo storage user = userInfo[account];
+        UserInfo storage total = userInfo[address(this)];
+
+        if (account != address(0)) {
+            uint256 userPending = user.amount * accCakePerShare / 1e12 - user.rewardDebt;
+            user.accruedReward = user.accruedReward + userPending;
+            uint256 totalPending = total.amount * accCakePerShare / 1e12 - total.rewardDebt;
+            total.accruedReward = total.accruedReward + totalPending;
+        }
+
+        _;
+
+        if (account != address(0)) {
+            user.rewardDebt = user.amount * accCakePerShare / 1e12;
+            total.rewardDebt = total.amount * accCakePerShare / 1e12;
+        }
+    }
+
+    modifier onlyOperator() {
+        require(msg.sender == operator, "Only the contract operator may perform this action");
+        _;
+    }
+
+    /* ========== EVENTS ========== */
+
+    event Withdrawn(address indexed user, uint256 autoCompoundStakingTokenAmount, uint256 stakingRewardsStakingTokenAmount);
+    event StakedToStakingReward(uint256 stakeAmount);
+    event Compounded(uint256 lpAmount);
+    event RewardPaid(address indexed user, uint256 rewardLPAmount);
+    event UpdateOperator(address newOperator);
+}

--- a/contracts/cake_farm/RewardCompoundCakeFarm.sol
+++ b/contracts/cake_farm/RewardCompoundCakeFarm.sol
@@ -70,8 +70,6 @@ contract RewardCompoundCakeFarm is BaseSingleTokenStakingCakeFarm {
         require(_poolLP == address(_lp), "Wrong LP token");
     }
 
-    receive() external payable {}
-
     /* ========== VIEWS ========== */
 
     /// @notice Get the reward share earned by specified account.

--- a/contracts/cake_farm/RewardCompoundCakeFarm.sol
+++ b/contracts/cake_farm/RewardCompoundCakeFarm.sol
@@ -3,10 +3,11 @@ pragma solidity ^0.8.0;
 import "./BaseSingleTokenStakingCakeFarm.sol";
 import "../interfaces/IStakingRewards.sol";
 
-/// @title A wrapper contract over StakingRewards contract that allows single asset in/out,
-/// with autocompound functionality. Autocompound function collects the reward earned, convert
-/// them to staking token and stake.
-/// @notice Asset tokens are token0 and token1. Staking token is the LP token of token0/token1.
+/// @title A wrapper contract over MasterChef and StakingRewards contract that allows single asset in/out,
+/// with autocompound functionality. Autocompound function (1) collects the MasterChef reward earned, convert
+/// them to staking token of StakingRewards and stake, and (2) collects the StakingRewards rewards earned and 
+/// convert to staking token of MasterChef and stake.
+/// @notice Asset tokens are token0 and token1. Staking token of MasterChef is the LP token of token0/token1.
 /// User will be earning LP tokens compounded, not the reward token from StakingRewards contract.
 contract RewardCompoundCakeFarm is BaseSingleTokenStakingCakeFarm {
     using SafeERC20 for IERC20;

--- a/contracts/cake_farm/RewardCompoundCakeFarm.sol
+++ b/contracts/cake_farm/RewardCompoundCakeFarm.sol
@@ -45,7 +45,7 @@ contract RewardCompoundCakeFarm is BaseSingleTokenStakingCakeFarm {
         uint256 _pid,
         IPancakePair _lp,
         IConverter _converter,
-        address _masterChef,
+        IMasterChef _masterChef,
         IStakingRewards _stakingRewards
     ) external {
         require(keccak256(abi.encodePacked(name)) == keccak256(abi.encodePacked("")), "Already initialized");
@@ -61,7 +61,7 @@ contract RewardCompoundCakeFarm is BaseSingleTokenStakingCakeFarm {
         token0 = IERC20(_lp.token0());
         token1 = IERC20(_lp.token1());
         converter = _converter;
-        masterChef = IMasterChef(_masterChef);
+        masterChef = _masterChef;
         stakingRewards = _stakingRewards;
         stakingRewardsStakingToken = IERC20(stakingRewards.stakingToken());
         stakingRewardsRewardsToken = IERC20(stakingRewards.rewardsToken());
@@ -70,9 +70,9 @@ contract RewardCompoundCakeFarm is BaseSingleTokenStakingCakeFarm {
         require(_poolLP == address(_lp), "Wrong LP token");
     }
 
-    /* ========== VIEWS ========== */
-
     receive() external payable {}
+
+    /* ========== VIEWS ========== */
 
     /// @notice Get the reward share earned by specified account.
     function _share(address account) public view returns (uint256) {
@@ -91,7 +91,7 @@ contract RewardCompoundCakeFarm is BaseSingleTokenStakingCakeFarm {
     }
 
     /// @notice Get the total reward share in this contract.
-    /// @notice Total reward is tracked with `_rewards[address(this)]` and `_userRewardPerTokenPaid[address(this)]`
+    /// @notice Total reward is tracked with `userInfo[address(this)].accruedReward`
     function _shareTotal() public view returns (uint256) {
         return _share(address(this));
     }
@@ -239,7 +239,7 @@ contract RewardCompoundCakeFarm is BaseSingleTokenStakingCakeFarm {
         if (reward > 0) {
             // compoundedLPRewardAmount: based on user's reward and totalReward,
             // determine how many compouned(read: extra) LP amount can user take away.
-            // NOTE: totalReward = _rewards[address(this)];
+            // NOTE: totalReward = userInfo[address(this)].accruedReward;
             uint256 compoundedLPRewardAmount = lpAmountCompounded * reward / totalReward;
 
             // Update records:

--- a/contracts/cake_farm/TempStakeManagerCakeFarm.sol
+++ b/contracts/cake_farm/TempStakeManagerCakeFarm.sol
@@ -1,0 +1,265 @@
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import "./BaseSingleTokenStakingCakeFarm.sol";
+
+/// @title A contract for temporarily managin stake for users. 
+/// @notice When main contract calls `stake`, it receives LP token from main contract and stake it.
+/// When main contract calls `exit`, it withdraws stake, get reward and convert reward to LP token
+/// and transfer LP token to main contract.
+contract TempStakeManagerCakeFarm is BaseSingleTokenStakingCakeFarm {
+    using EnumerableSet for EnumerableSet.AddressSet;
+    using SafeERC20 for IERC20;
+
+    struct BalanceDiff {
+        uint256 balBefore;
+        uint256 balAfter;
+        uint256 balDiff;
+    }
+
+    struct ExitRelatedVars {
+        uint256 lpAmount;
+        uint256 reward;
+        IERC20 rewardToken;
+    }
+
+    struct minAmountVars {
+        uint256 rewardToToken0Swap;
+        uint256 tokenInToTokenOutSwap;
+        uint256 tokenInAddLiq;
+        uint256 tokenOutAddLiq;
+    }
+
+    /* ========== STATE VARIABLES ========== */
+
+    address public mainContract;
+    EnumerableSet.AddressSet private _stakerList;
+
+    /* ========== CONSTRUCTOR ========== */
+
+    function initialize(
+        string memory _name,
+        address _owner,
+        address _BCNT,
+        IERC20 _cake,
+        uint256 _pid,
+        IConverter _converter,
+        IMasterChef _masterChef,
+        address _mainContract
+    ) external {
+        require(keccak256(abi.encodePacked(name)) == keccak256(abi.encodePacked("")), "Already initialized");
+        super.initializePausable(_owner);
+        super.initializeReentrancyGuard();
+
+        name = _name;
+        BCNT = _BCNT;
+        cake = _cake;
+        pid = _pid;
+        converter = _converter;
+        masterChef = _masterChef;
+
+        (address _poolLP, , ,) = masterChef.poolInfo(_pid);
+        lp = IERC20(_poolLP);
+        token0 = IERC20(IPancakePair(_poolLP).token0());
+        token1 = IERC20(IPancakePair(_poolLP).token1());
+
+        mainContract = _mainContract;
+    }
+
+    /* ========== VIEWS ========== */
+
+    function getStakerAt(uint256 index) public view returns (address) {
+        return _stakerList.at(index);
+    }
+
+    function getStakersUpto(uint256 index) public view returns (address[] memory) {
+        address[] memory stakerList = new address[](index);
+        for (uint256 i = 0; i < index; i++) {
+            stakerList[i] = (_stakerList.at(i));
+        }
+        return stakerList;
+    }
+
+    function getAllStakers() public view returns (address[] memory) {
+        uint256 numStaker = _stakerList.length();
+        address[] memory stakerList = new address[](numStaker);
+        for (uint256 i = 0; i < numStaker; i++) {
+            stakerList[i] = (_stakerList.at(i));
+        }
+        return stakerList;
+    }
+
+    /// @dev Get the reward earned by specified account
+    function earned(address account) public override view returns (uint256) {
+        UserInfo memory user = userInfo[account];
+
+        uint256 totalAllocPoint = masterChef.totalAllocPoint();
+        uint256 cakePerBlock = masterChef.cakePerBlock();
+        (, uint256 allocPoint, uint256 lastRewardBlock, uint256 accCakePerShare) = masterChef.poolInfo(pid);
+        uint256 lpSupply = lp.balanceOf(address(masterChef));
+        if (block.number > lastRewardBlock && lpSupply != 0) {
+            uint256 multiplier = masterChef.getMultiplier(lastRewardBlock, block.number);
+            uint256 cakeReward = (multiplier * cakePerBlock * allocPoint) / totalAllocPoint;
+            accCakePerShare = accCakePerShare + ((cakeReward * 1e12) / lpSupply);
+        }
+        return user.amount * accCakePerShare / 1e12 - user.rewardDebt + user.accruedReward;
+    }
+
+    /* ========== MUTATIVE FUNCTIONS ========== */
+
+    /// @notice Override and intentionally failing the normal stake function
+    function stake(
+        bool isToken0,
+        uint256 amount,
+        uint256 minReceivedTokenAmountSwap,
+        uint256 minToken0AmountAddLiq,
+        uint256 minToken1AmountAddLiq
+    ) public override {
+        revert("This function is not available");
+    }
+
+    /// @notice Receive LP tokens from main contract and stake it.
+    /// @param staker Account that is staking
+    /// @param lpAmount Amount of lp token staker staked and transfer to this contract
+    function stake(address staker, uint256 lpAmount) public onlyMainContract nonReentrant notPaused updateReward(staker) {
+        _stake(staker, lpAmount);
+
+        _stakerList.add(staker);
+
+        emit Staked(staker, lpAmount);
+    }
+
+    /// @notice Override and intentionally failing the normal withdraw function
+    function withdraw(uint256 minToken0AmountConverted, uint256 minToken1AmountConverted, uint256 token0Percentage, uint256 amount) public override {
+        revert("This function is not available");
+    }
+
+    /// @notice Override and intentionally failing the normal getReward function
+    function getReward(uint256 minToken0AmountConverted, uint256 minToken1AmountConverted, uint256 minBCNTAmountConverted) public override {
+        revert("This function is not available");
+    }
+
+    /// @notice Override and intentionally failing the inherited exit function
+    function exit(uint256 minToken0AmountConverted, uint256 minToken1AmountConverted, uint256 minBCNTAmountConverted, uint256 token0Percentage) public override {
+        revert("This function is not available");
+    }
+
+    /// @notice Withdraw stake from MasterChef, get the reward out and convert reward to LP token
+    /// and transfer LP token to main contract.
+    /// @param staker Account that is staking
+    /// @param minAmounts The minimum amounts of
+    /// 1. token0 expected to receive when swapping reward token for token0
+    /// 2. tokenOut expected to receive when swapping inToken for outToken
+    /// 3. tokenIn expected to add when adding liquidity
+    /// 4. tokenOut expected to add when adding liquidity
+    /// @return lpAmount Amount of LP token withdrawn
+    /// @return convertedLPAmount Amount of LP token converted from reward
+    function exit(address staker, minAmountVars memory minAmounts) external onlyMainContract nonReentrant updateReward(staker) returns (uint256, uint256) {
+        ExitRelatedVars memory exitVars;
+        exitVars.lpAmount = userInfo[staker].amount;
+        exitVars.reward = userInfo[staker].accruedReward;
+
+        // Clean up staker's balance
+        userInfo[address(this)].amount = userInfo[address(this)].amount - exitVars.lpAmount;
+        userInfo[staker].amount = 0;
+        // Withdraw stake
+        masterChef.withdraw(pid, exitVars.lpAmount);
+
+        // Get reward and convert to LP token
+        BalanceDiff memory lpAmountDiff;
+        if (exitVars.reward > 0) {
+            userInfo[staker].accruedReward = 0;
+
+            exitVars.rewardToken = cake;
+            lpAmountDiff.balBefore = lp.balanceOf(address(this));
+
+            BalanceDiff memory token0Diff;
+            token0Diff.balBefore = token0.balanceOf(address(this));
+            // Convert rewards to token0
+            exitVars.rewardToken.safeApprove(address(converter), exitVars.reward);
+            converter.convert(address(exitVars.rewardToken), exitVars.reward, 100, address(token0), minAmounts.rewardToToken0Swap, address(this));
+            token0Diff.balAfter = token0.balanceOf(address(this));
+            token0Diff.balDiff = (token0Diff.balAfter - token0Diff.balBefore);
+
+            // Convert converted token0 to LP tokens
+            token0.safeApprove(address(converter), token0Diff.balDiff);
+            converter.convertAndAddLiquidity(
+                address(token0),
+                token0Diff.balDiff,
+                address(token1),
+                minAmounts.tokenInToTokenOutSwap,
+                minAmounts.tokenInAddLiq,
+                minAmounts.tokenOutAddLiq,
+                address(this)
+            );
+
+            lpAmountDiff.balAfter = lp.balanceOf(address(this));
+            lpAmountDiff.balDiff = (lpAmountDiff.balAfter - lpAmountDiff.balBefore);
+            emit ConvertedLP(staker, lpAmountDiff.balDiff);
+        }
+
+        _stakerList.remove(staker);
+
+        // Transfer withdrawn LP amount plus converted LP amount
+        lp.transfer(mainContract, exitVars.lpAmount + lpAmountDiff.balDiff);
+        emit Withdrawn(staker, exitVars.lpAmount);
+
+        return (exitVars.lpAmount, lpAmountDiff.balDiff);
+    }
+
+    function _convertCakeToBCNTAndTransfer(address receiver, uint256 amount, uint256 minBCNTAmountConverted) internal {
+        // Convert Cake to BCNT
+        cake.safeApprove(address(converter), amount);
+        converter.convert(address(cake), amount, 100, BCNT, minBCNTAmountConverted, receiver);
+    }
+
+    /// @notice Withdraw stake from MasterChef, get the reward out send them to staker
+    /// @param staker Account that is aborting
+    /// @param minBCNTAmountConverted The minimum amount of BCNT received swapping Cake for BCNT
+    function abort(address staker, uint256 minBCNTAmountConverted) external onlyMainContract nonReentrant updateReward(staker) {
+        uint256 lpAmount = userInfo[staker].amount;
+        if (lpAmount > 0) {
+            // Clean up staker's balance
+            userInfo[address(this)].amount = userInfo[address(this)].amount - lpAmount;
+            userInfo[staker].amount = 0;
+            // Withdraw stake
+            masterChef.withdraw(pid, lpAmount);
+            // Transfer withdrawn LP
+            lp.transfer(staker, lpAmount);
+            emit Abort(staker, lpAmount);
+        }
+
+        // Get reward
+        uint256 reward = userInfo[staker].accruedReward;
+        if (reward > 0) {
+            // Clean up staker's reward
+            userInfo[staker].accruedReward = 0;
+            // Transfer reward
+            _convertCakeToBCNTAndTransfer(staker, reward, minBCNTAmountConverted);
+            emit RewardPaid(staker, reward);
+        }
+
+        _stakerList.remove(staker);
+    }
+
+    /* ========== RESTRICTED FUNCTIONS ========== */
+
+    function updateMainContract(address newMainContract) external onlyOwner {
+        mainContract = newMainContract;
+    }
+
+    /* ========== MODIFIERS ========== */
+
+    modifier onlyMainContract() {
+        require(msg.sender == mainContract, "Only the contract operator may perform this action");
+        _;
+    }
+
+    /* ========== EVENTS ========== */
+
+    event ConvertedLP(address indexed user, uint256 rewardLPAmount);
+    event Abort(address indexed user, uint256 lpAmount);
+    event RewardPaid(address indexed user, uint256 rewardAmount);
+}

--- a/contracts/interfaces/ITempStakeManagerCakeFarm.sol
+++ b/contracts/interfaces/ITempStakeManagerCakeFarm.sol
@@ -1,0 +1,6 @@
+pragma solidity >=0.5.0 <0.9.0;
+import "../interfaces/ITempStakeManager.sol";
+
+interface ITempStakeManagerCakeFarm is ITempStakeManager {
+    function abort(address staker, uint256 minBCNTAmountConverted) external;
+}

--- a/contracts/stubs/stubPancakeRouter.sol
+++ b/contracts/stubs/stubPancakeRouter.sol
@@ -15,7 +15,7 @@ contract StubPancakeRouter {
     function _getLPAddr(address tokenA, address tokenB) internal returns (address) {
         if (lpAddr[tokenA][tokenB] != address(0)) return lpAddr[tokenA][tokenB];
         else if (lpAddr[tokenB][tokenA] != address(0)) return lpAddr[tokenB][tokenA];
-        else revert("Pari not exist");
+        else revert("Pair not exist");
     }
 
     function setLPAddr(address tokenA, address tokenB, address lp) external {

--- a/test/Bet.ts
+++ b/test/Bet.ts
@@ -269,7 +269,6 @@ describe("Bet", function () {
         expect(await bet.callStatic.token1()).to.equal(token1.address)
         expect(await bet.callStatic.operator()).to.equal(operatorAddress)
         expect(await bet.callStatic.liquidityProvider()).to.equal(liquidityProviderAddress)
-        expect(await bet.callStatic.router()).to.equal(pancakeRouter.address)
         expect(await bet.callStatic.tempStakeManager()).to.equal(tempStakeManager.address)
         expect(await bet.callStatic.penaltyPercentage()).to.equal(penaltyPercentage)
 
@@ -829,6 +828,7 @@ describe("Bet", function () {
             const expectedStakingRewardsReward = betEarnedRewardsBefore.add(rewardBeforeCookAmountBefore).mul(userRewardShareBefore).div(totalRewardShareBefore)
             expect(actualStakingRewardsReward).to.be.gte(expectedStakingRewardsReward)
             // Diff should be less than 1%
+            console.log(`StakingRewards reward amount diff: ${actualStakingRewardsReward.sub(expectedStakingRewardsReward)}`)
             expect(actualStakingRewardsReward.sub(expectedStakingRewardsReward)).to.be.lt(actualStakingRewardsReward.div(100))
             receivedBonusAmount = receivedBonusAmount.add(actualStakingRewardsReward)
         }
@@ -996,6 +996,7 @@ describe("Bet", function () {
             receivedBonusAmount.gt(expectedBonusAmountReceived) ?
             receivedBonusAmount.sub(expectedBonusAmountReceived) : expectedBonusAmountReceived.sub(receivedBonusAmount)
         )
+        console.log(`Bonus amount diff: ${bonusAmountDiff}`)
         expect(bonusAmountDiff).to.be.lt(10**6)
         // Operator should receive the other part of bonus
         const liquidityProviderRewardShareAfter = await bet.callStatic._share(liquidityProviderAddress)

--- a/test/Bet.ts
+++ b/test/Bet.ts
@@ -251,7 +251,6 @@ describe("Bet", function () {
             stakingRewards.address,
             operatorAddress,
             liquidityProviderAddress,
-            pancakeRouter.address,
             tempStakeManager.address,
             penaltyPercentage
         ])
@@ -323,7 +322,6 @@ describe("Bet", function () {
             stakingRewards.address,
             operatorAddress,
             liquidityProviderAddress,
-            pancakeRouter.address,
             tempStakeManager.address,
             penaltyPercentage
         )).to.be.revertedWith("Already initialized")

--- a/test/BetCakeFarm.ts
+++ b/test/BetCakeFarm.ts
@@ -1,0 +1,1216 @@
+import { expect, use } from "chai"
+import { ethers, network } from "hardhat"
+import { BigNumber, Contract, Signer, Wallet } from "ethers"
+import { mineBlocks } from "./utils/network"
+import { parseLogsByName } from "./utils/events"
+
+
+describe("Bet", function () {
+    // Roles
+    let operator: Signer, operatorAddress: string
+    let liquidityProvider: Signer, liquidityProviderAddress: string
+    let receiver: Signer, receiverAddress: string
+    let owner: Signer
+    let user: Signer, userAddr: string
+
+    // Contracts
+    let wbnb: Contract, wwbnbLP: Contract, mwbnbLP: Contract
+    let woof: Contract, meow: Contract, mwLP: Contract
+    let bcnt: Contract, mbcntLP: Contract, wbcntLP: Contract
+    let cake: Contract, cbLP: Contract, cwbnbLP: Contract
+    let token0: Contract, token1: Contract, lpToken: Contract, isToken01NativeTokenSetting: boolean
+    let pancakeRouter: Contract
+    let masterChef: Contract
+    let poolId: BigNumber, cakerPerBlock: BigNumber
+    let converterImpl: Contract
+    let converter: Contract
+    let betImpl: Contract
+    let betCakeFarm: Contract
+    let tempStakeManagerImpl: Contract
+    let tempStakeManager: Contract
+
+    const MAX_INT = "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+
+    const penaltyPercentage = 50
+
+    const tbnbAddr = "0x509Ba9040dc4091da93f07cdD1e03Dea208e28bf"
+    const woofAddr = "0x8dEdf46654B5A8d87a16D92C86ABB769578455B3"
+    const meowAddr = "0x505A32c45676777e94689D16F30Df2a0Fa5dBa8e"
+    const mwLPAddr = "0x304D9a9969Ea753b1A5d4eB9F3542cb870f4a843"
+    const tusdAddr = "0xFD313Bc4bDc701726316DD39E91E7ef45A43F0F7"
+    const wuLPAddr = "0x9BC7cb927beeF43E6AcD42275B93CD26854F595f"
+    const pancakeRouterAddr = "0x10ED43C718714eb63d5aA57B78B54704E256024E"
+
+    const ownerAddr = "0xb0123A6B61F0b5500EA92F33F24134c814364e3a"
+
+    let numFFBlocks
+    const minReceivedToken0Amount = 0, minReceivedToken1Amount = 0, minReceivedLPAmount = 0, minBCNTAmountConverted = 0
+
+    before(async () => {
+        [receiver, operator, liquidityProvider] = await ethers.getSigners()
+        receiverAddress = await receiver.getAddress()
+        operatorAddress = await operator.getAddress()
+        liquidityProviderAddress = await liquidityProvider.getAddress()
+        
+        await network.provider.request({
+            method: "hardhat_impersonateAccount",
+            params: [ownerAddr]
+        })
+
+        owner = ethers.provider.getSigner(ownerAddr)
+        user = owner
+        userAddr = ownerAddr
+        
+        // Deploy new contracts for testing
+        const deciaml = 18
+        const initSupply = ethers.utils.parseUnits("10000000")
+        wbnb = await (
+            await ethers.getContractFactory("WETH9", operator)
+        ).deploy()
+        const depositValue = ethers.utils.parseEther('9000')
+        await wbnb.connect(operator).deposit({ value: depositValue })
+        expect(await wbnb.totalSupply()).equal(depositValue)
+        cake = await (
+            await ethers.getContractFactory("mintersBEP2EToken", operator)
+        ).deploy("CAKE", "CAKE", deciaml, initSupply)
+        bcnt = await (
+            await ethers.getContractFactory("mintersBEP2EToken", operator)
+        ).deploy("BCNT", "BCNT", deciaml, initSupply)
+        meow = await (
+            await ethers.getContractFactory("mintersBEP2EToken", operator)
+        ).deploy("MEOW", "MEOW", deciaml, initSupply)
+        expect(await meow.totalSupply()).equal(initSupply)
+        woof = await (
+            await ethers.getContractFactory("mintersBEP2EToken", operator)
+        ).deploy("WOOF", "WOOF", deciaml, initSupply)
+        expect(await woof.totalSupply()).equal(initSupply)
+        mwLP = await (
+            await ethers.getContractFactory("StubPancakePair", operator)
+        ).deploy(meow.address, woof.address)
+        mwbnbLP = await (
+            await ethers.getContractFactory("StubPancakePair", operator)
+        ).deploy(meow.address, wbnb.address)
+        wwbnbLP = await (
+            await ethers.getContractFactory("StubPancakePair", operator)
+        ).deploy(woof.address, wbnb.address)
+        cwbnbLP = await (
+            await ethers.getContractFactory("StubPancakePair", operator)
+        ).deploy(cake.address, wbnb.address)
+        cbLP = await (
+            await ethers.getContractFactory("StubPancakePair", operator)
+        ).deploy(cake.address, bcnt.address)
+        mbcntLP = await (
+            await ethers.getContractFactory("StubPancakePair", operator)
+        ).deploy(meow.address, bcnt.address)
+        wbcntLP = await (
+            await ethers.getContractFactory("StubPancakePair", operator)
+        ).deploy(woof.address, bcnt.address)
+
+        pancakeRouter = await (
+            await ethers.getContractFactory("StubPancakeRouter", operator)
+        ).deploy()
+        await pancakeRouter.setLPAddr(meow.address, woof.address, mwLP.address)
+        expect(await pancakeRouter.lpAddr(meow.address, woof.address)).to.equal(mwLP.address)
+        await pancakeRouter.setLPAddr(meow.address, wbnb.address, mwbnbLP.address)
+        expect(await pancakeRouter.lpAddr(meow.address, wbnb.address)).to.equal(mwbnbLP.address)
+        await pancakeRouter.setLPAddr(woof.address, wbnb.address, wwbnbLP.address)
+        expect(await pancakeRouter.lpAddr(woof.address, wbnb.address)).to.equal(wwbnbLP.address)
+        await pancakeRouter.setLPAddr(cake.address, wbnb.address, cwbnbLP.address)
+        expect(await pancakeRouter.lpAddr(cake.address, wbnb.address)).to.equal(cwbnbLP.address)
+        await pancakeRouter.setLPAddr(cake.address, bcnt.address, cbLP.address)
+        expect(await pancakeRouter.lpAddr(cake.address, bcnt.address)).to.equal(cbLP.address)
+        await pancakeRouter.setLPAddr(woof.address, bcnt.address, wbcntLP.address)
+        expect(await pancakeRouter.lpAddr(woof.address, bcnt.address)).to.equal(wbcntLP.address)
+        await pancakeRouter.setLPAddr(meow.address, bcnt.address, mbcntLP.address)
+        expect(await pancakeRouter.lpAddr(meow.address, bcnt.address)).to.equal(mbcntLP.address)
+
+        // Add liquidity
+        await cake.connect(operator).approve(pancakeRouter.address, MAX_INT)
+        await bcnt.connect(operator).approve(pancakeRouter.address, MAX_INT)
+        await meow.connect(operator).approve(pancakeRouter.address, MAX_INT)
+        await woof.connect(operator).approve(pancakeRouter.address, MAX_INT)
+        await wbnb.connect(operator).approve(pancakeRouter.address, MAX_INT)
+        // Add MEOW/WOOF liquidity
+        await pancakeRouter.connect(operator).addLiquidity(
+            meow.address,
+            woof.address,
+            ethers.utils.parseUnits("1000000"),
+            ethers.utils.parseUnits("1000000"),
+            0,
+            0,
+            operatorAddress,
+            0
+        )
+        expect(await mwLP.callStatic.balanceOf(operatorAddress)).to.equal(ethers.utils.parseUnits("2000000"))
+        // Add MEOW/WBNB liquidity
+        await pancakeRouter.connect(operator).addLiquidity(
+            meow.address,
+            wbnb.address,
+            ethers.utils.parseUnits("2000"),
+            ethers.utils.parseUnits("2000"),
+            0,
+            0,
+            operatorAddress,
+            0
+        )
+        expect(await mwbnbLP.callStatic.balanceOf(operatorAddress)).to.equal(ethers.utils.parseUnits("4000"))
+        // Add WOOF/WBNB liquidity
+        await pancakeRouter.connect(operator).addLiquidity(
+            woof.address,
+            wbnb.address,
+            ethers.utils.parseUnits("2000"),
+            ethers.utils.parseUnits("2000"),
+            0,
+            0,
+            operatorAddress,
+            0
+        )
+        expect(await wwbnbLP.callStatic.balanceOf(operatorAddress)).to.equal(ethers.utils.parseUnits("4000"))
+        // Add CAKE/WBNB liquidity
+        await pancakeRouter.connect(operator).addLiquidity(
+            cake.address,
+            wbnb.address,
+            ethers.utils.parseUnits("2000"),
+            ethers.utils.parseUnits("2000"),
+            0,
+            0,
+            operatorAddress,
+            0
+        )
+        expect(await cwbnbLP.callStatic.balanceOf(operatorAddress)).to.equal(ethers.utils.parseUnits("4000"))
+        // Add CAKE/BCNT liquidity
+        await pancakeRouter.connect(operator).addLiquidity(
+            cake.address,
+            bcnt.address,
+            ethers.utils.parseUnits("1000000"),
+            ethers.utils.parseUnits("1000000"),
+            0,
+            0,
+            operatorAddress,
+            0
+        )
+        expect(await cbLP.callStatic.balanceOf(operatorAddress)).to.equal(ethers.utils.parseUnits("2000000"))
+        // Add MEOW/BCNT liquidity
+        await pancakeRouter.connect(operator).addLiquidity(
+            meow.address,
+            bcnt.address,
+            ethers.utils.parseUnits("1000000"),
+            ethers.utils.parseUnits("1000000"),
+            0,
+            0,
+            operatorAddress,
+            0
+        )
+        expect(await mbcntLP.callStatic.balanceOf(operatorAddress)).to.equal(ethers.utils.parseUnits("2000000"))
+        // Add WOOF/BCNT liquidity
+        await pancakeRouter.connect(operator).addLiquidity(
+            woof.address,
+            bcnt.address,
+            ethers.utils.parseUnits("1000000"),
+            ethers.utils.parseUnits("1000000"),
+            0,
+            0,
+            operatorAddress,
+            0
+        )
+        expect(await wbcntLP.callStatic.balanceOf(operatorAddress)).to.equal(ethers.utils.parseUnits("2000000"))
+
+
+        // Two token setting
+        isToken01NativeTokenSetting = false
+        poolId = BigNumber.from(1)
+        token0 = meow
+        token1 = woof
+        lpToken = mwLP
+
+        // Three token setting
+        // isToken01NativeTokenSetting = true
+        // poolId = BigNumber.from(2)
+        // token0 = meow
+        // token1 = wbnb
+        // lpToken = mwbnbLP
+
+        // Set up MasterChef pool
+        cakerPerBlock = ethers.utils.parseUnits("10")
+        masterChef = await (
+            await ethers.getContractFactory("MasterChef", operator)
+        ).deploy(
+            cake.address,
+            cakerPerBlock,
+            await ethers.provider.getBlockNumber()
+        )
+        // Set up M/W pool in MasterChef
+        const allocPoint = 1000
+        const updatePools = true
+        await masterChef.connect(operator).add(allocPoint, mwLP.address, updatePools)
+        expect(await masterChef.callStatic.poolLength()).to.equal(2)
+        // Set up M/WBNB pool in MasterChef
+        await masterChef.connect(operator).add(allocPoint, mwbnbLP.address, updatePools)
+        expect(await masterChef.callStatic.poolLength()).to.equal(3)
+        // Add Cake to MasterChef
+        await cake.connect(operator).transfer(masterChef.address, ethers.utils.parseUnits("1000000"))
+
+        const converterName = "Token Converter"
+        converterImpl = await (
+            await ethers.getContractFactory("Converter", operator)
+        ).deploy()
+        const converterInitData = converterImpl.interface.encodeFunctionData("initialize", [
+            wbnb.address,
+            converterName,
+            ownerAddr,
+            pancakeRouter.address
+        ])
+        converter = await (
+            await ethers.getContractFactory("UpgradeProxy", operator)
+        ).deploy(
+            converterImpl.address,
+            converterInitData
+        )
+        // Change instance ABI from UpgradeProxy to implementation
+        converter = converterImpl.attach(converter.address)
+        expect(await converter.callStatic.NATIVE_TOKEN()).to.equal(wbnb.address)
+        expect(await converter.callStatic.name()).to.equal(converterName)
+        expect(await converter.callStatic.owner()).to.equal(ownerAddr)
+        expect(await converter.callStatic.router()).to.equal(pancakeRouter.address)
+
+        const tempStakeManagerName = "MEOW/WOOF TempStakeManager"
+        tempStakeManagerImpl = await (
+            await ethers.getContractFactory("TempStakeManagerCakeFarm", operator)
+        ).deploy()
+        tempStakeManager = await (
+            await ethers.getContractFactory("UpgradeProxy", operator)
+        ).deploy(
+            tempStakeManagerImpl.address,
+            "0x"
+        )
+        tempStakeManager = tempStakeManagerImpl.attach(tempStakeManager.address)
+
+        const betName = "BetCakeFarm"
+        betImpl = await (
+            await ethers.getContractFactory("BetCakeFarm", operator)
+        ).deploy()
+        const betInitData = betImpl.interface.encodeFunctionData("initialize", [
+            betName,
+            ownerAddr,
+            bcnt.address,
+            cake.address,
+            poolId,
+            converter.address,
+            masterChef.address,
+            operatorAddress,
+            liquidityProviderAddress,
+            tempStakeManager.address,
+            penaltyPercentage
+        ])
+        betCakeFarm = await (
+            await ethers.getContractFactory("UpgradeProxy", operator)
+        ).deploy(
+            betImpl.address,
+            betInitData
+        )
+        // Change Bet instance ABI from UpgradeProxy to Bet implementation
+        betCakeFarm = betImpl.attach(betCakeFarm.address)
+        expect(await betCakeFarm.callStatic.implementation()).to.equal(betImpl.address)
+        expect(await betCakeFarm.callStatic.name()).to.equal(betName)
+        expect(await betCakeFarm.callStatic.BCNT()).to.equal(bcnt.address)
+        expect(await betCakeFarm.callStatic.cake()).to.equal(cake.address)
+        expect(await betCakeFarm.callStatic.converter()).to.equal(converter.address)
+        expect(await betCakeFarm.callStatic.masterChef()).to.equal(masterChef.address)
+        expect(await betCakeFarm.callStatic.pid()).to.equal(poolId)
+        expect(await betCakeFarm.callStatic.token0()).to.equal(token0.address)
+        expect(await betCakeFarm.callStatic.token1()).to.equal(token1.address)
+        expect(await betCakeFarm.callStatic.operator()).to.equal(operatorAddress)
+        expect(await betCakeFarm.callStatic.liquidityProvider()).to.equal(liquidityProviderAddress)
+        expect(await betCakeFarm.callStatic.tempStakeManager()).to.equal(tempStakeManager.address)
+        expect(await betCakeFarm.callStatic.penaltyPercentage()).to.equal(penaltyPercentage)
+
+        // Initialize TempStakeManager
+        await tempStakeManager.initialize(
+            tempStakeManagerName,
+            operatorAddress,
+            bcnt.address,
+            cake.address,
+            poolId,
+            converter.address,
+            masterChef.address,
+            betCakeFarm.address
+        )
+        expect(await tempStakeManager.callStatic.implementation()).to.equal(tempStakeManagerImpl.address)
+        expect(await tempStakeManager.callStatic.name()).to.equal(tempStakeManagerName)
+        expect(await tempStakeManager.callStatic.cake()).to.equal(cake.address)
+        expect(await tempStakeManager.callStatic.token0()).to.equal(token0.address)
+        expect(await tempStakeManager.callStatic.token1()).to.equal(token1.address)
+        expect(await tempStakeManager.callStatic.converter()).to.equal(converter.address)
+        expect(await tempStakeManager.callStatic.masterChef()).to.equal(masterChef.address)
+        expect(await tempStakeManager.callStatic.pid()).to.equal(poolId)
+        expect(await tempStakeManager.callStatic.owner()).to.equal(operatorAddress)
+        expect(await tempStakeManager.callStatic.mainContract()).to.equal(betCakeFarm.address)
+
+        // Transfer ether to owner
+        await operator.sendTransaction({to: ownerAddr, value: ethers.utils.parseUnits('100')})
+        // Transfer BCNT to owner
+        await bcnt.connect(operator).transfer(ownerAddr, ethers.utils.parseUnits("100000"))
+        // Transfer tokens to owner
+        await meow.connect(operator).transfer(ownerAddr, ethers.utils.parseUnits("100000"))
+        await woof.connect(operator).transfer(ownerAddr, ethers.utils.parseUnits("100000"))
+        await wbnb.connect(operator).transfer(ownerAddr, ethers.utils.parseUnits("1000"))
+        // Transfer LP tokens to owner
+        await mwLP.connect(operator).transfer(ownerAddr, ethers.utils.parseUnits("20000"))
+        await mwbnbLP.connect(operator).transfer(ownerAddr, ethers.utils.parseUnits("1000"))
+        await wwbnbLP.connect(operator).transfer(ownerAddr, ethers.utils.parseUnits("1000"))
+    })
+
+    it("Should not re-initialize", async () => {
+        const betName = "BLABLABLA"
+        await expect(betCakeFarm.connect(user).initialize(
+            betName,
+            ownerAddr,
+            bcnt.address,
+            cake.address,
+            poolId,
+            converter.address,
+            masterChef.address,
+            operatorAddress,
+            liquidityProviderAddress,
+            tempStakeManager.address,
+            penaltyPercentage
+        )).to.be.revertedWith("Already initialized")
+
+        const tempStakeManagerName = "BLABLABLA"
+        await expect(tempStakeManager.connect(user).initialize(
+            tempStakeManagerName,
+            operatorAddress,
+            bcnt.address,
+            cake.address,
+            poolId,
+            converter.address,
+            masterChef.address,
+            betCakeFarm.address
+        )).to.be.revertedWith("Already initialized")
+    })
+
+    it("Should not upgrade by non-owner", async () => {
+        await expect(betCakeFarm.connect(receiver).upgradeTo(
+            pancakeRouter.address
+        )).to.be.revertedWith("Only the contract owner may perform this action")
+
+        await expect(tempStakeManager.connect(receiver).upgradeTo(
+            pancakeRouter.address
+        )).to.be.revertedWith("Only the contract owner may perform this action")
+    })
+
+    it("Should stake with Token0", async () => {
+        const userStakeBalanceBefore = await betCakeFarm.callStatic.balanceOf(userAddr)
+
+        const betCakeFarmLPBalanceBefore = await lpToken.callStatic.balanceOf(betCakeFarm.address)
+        expect(betCakeFarmLPBalanceBefore).to.equal(0)
+        const betCakeFarmStakeBalanceBefore = (await masterChef.callStatic.userInfo(poolId, betCakeFarm.address))[0]
+
+        const stakeAmount = ethers.utils.parseUnits('100')
+        await token0.connect(user).approve(betCakeFarm.address, stakeAmount)
+
+        const isToken0 = true
+        const tx = await betCakeFarm.connect(user).stake(isToken0, stakeAmount, minReceivedToken1Amount, minReceivedToken0Amount, minReceivedToken1Amount)
+        const receipt = await tx.wait()
+
+        // Should not earn anything the moment staking
+        const earnedBonus = await betCakeFarm.callStatic.earned(userAddr)
+        expect(earnedBonus).to.equal(0)
+        // Should not accrue any LP tokens in Bet contract
+        const betCakeFarmLPBalanceAfter = await lpToken.callStatic.balanceOf(betCakeFarm.address)
+        expect(betCakeFarmLPBalanceAfter).to.equal(0)
+        // Should match stake amount
+        const betCakeFarmStakeBalanceAfter = (await masterChef.callStatic.userInfo(poolId, betCakeFarm.address))[0]
+        const stakedAmount = betCakeFarmStakeBalanceAfter.sub(betCakeFarmStakeBalanceBefore)
+        expect(stakedAmount).to.be.gt(0)
+        const userStakeBalanceAfter = await betCakeFarm.callStatic.balanceOf(userAddr)
+        expect(userStakeBalanceAfter.sub(userStakeBalanceBefore)).to.equal(stakedAmount)
+
+        const staked = ethers.utils.formatUnits(
+            stakedAmount,
+            18
+        )
+        console.log(`Staked ${staked} LP`)
+    })
+
+    it("Should stake with Token1", async () => {
+        const betCakeFarmStakeBalanceBefore = (await masterChef.callStatic.userInfo(poolId, betCakeFarm.address))[0]
+
+        const stakeAmount = ethers.utils.parseUnits('100')
+        await token1.connect(user).approve(betCakeFarm.address, stakeAmount)
+
+        const isToken0 = false
+        const tx = await betCakeFarm.connect(user).stake(isToken0, stakeAmount, minReceivedToken0Amount, minReceivedToken0Amount, minReceivedToken1Amount)
+        const receipt = await tx.wait()
+
+        const betCakeFarmStakeBalanceAfter = (await masterChef.callStatic.userInfo(poolId, betCakeFarm.address))[0]
+        const stakedAmount = betCakeFarmStakeBalanceAfter.sub(betCakeFarmStakeBalanceBefore)
+
+        const staked = ethers.utils.formatUnits(
+            stakedAmount,
+            18
+        )
+        console.log(`Staked ${staked} LP`)
+    })
+
+    it("Should stake with LP Token", async () => {
+        const betCakeFarmStakeBalanceBefore = (await masterChef.callStatic.userInfo(poolId, betCakeFarm.address))[0]
+
+        // LP token amount
+        const stakeAmount = ethers.utils.parseUnits('1')
+        await lpToken.connect(user).approve(betCakeFarm.address, stakeAmount)
+
+        const tx = await betCakeFarm.connect(user).stakeWithLP(stakeAmount)
+        const receipt = await tx.wait()
+
+        const betCakeFarmStakeBalanceAfter = (await masterChef.callStatic.userInfo(poolId, betCakeFarm.address))[0]
+        const stakedAmount = betCakeFarmStakeBalanceAfter.sub(betCakeFarmStakeBalanceBefore)
+        expect(stakedAmount).to.equal(stakeAmount)
+
+        const staked = ethers.utils.formatUnits(
+            stakedAmount,
+            18
+        )
+        console.log(`Staked ${staked} LP`)
+    })
+
+    it("Should stake with native token", async () => {
+        if (token0.address == wbnb.address || token1.address == wbnb.address) {
+            const betCakeFarmStakeBalanceBefore = (await masterChef.callStatic.userInfo(poolId, betCakeFarm.address))[0]
+
+            const stakeAmount = ethers.utils.parseUnits('1')
+            const tx = await betCakeFarm.connect(user).stakeWithNative(minReceivedToken0Amount, minReceivedToken0Amount, minReceivedToken1Amount,
+                {
+                    value: stakeAmount
+                }
+            )
+            const receipt = await tx.wait()
+
+            const betCakeFarmStakeBalanceAfter = (await masterChef.callStatic.userInfo(poolId, betCakeFarm.address))[0]
+            const stakedAmount = betCakeFarmStakeBalanceAfter.sub(betCakeFarmStakeBalanceBefore)
+
+            const staked = ethers.utils.formatUnits(
+                stakedAmount,
+                18
+            )
+            console.log(`Staked ${staked} LP`)
+        } else {
+            console.log("Skipped stake with native token test")
+        }
+    })
+
+    it("Should not earned before reward and profit returned", async () => {
+        const earnedBonusBefore = await betCakeFarm.callStatic.earned(userAddr)
+        expect(earnedBonusBefore).to.equal(0)
+
+        numFFBlocks = 1000
+        await mineBlocks(numFFBlocks)
+
+        const earnedBonusAfter = await betCakeFarm.callStatic.earned(userAddr)
+        expect(earnedBonusAfter).to.equal(earnedBonusBefore)
+    })
+
+    it("Should cook", async () => {
+        const operatorRewardAmountBefore = await bcnt.callStatic.balanceOf(operatorAddress)
+        const betCakeFarmRewardBalanceBefore = await bcnt.callStatic.balanceOf(betCakeFarm.address)
+
+        const userRewardShareBefore = await betCakeFarm.callStatic._share(userAddr)
+
+        const totalSupplyBefore = await betCakeFarm.callStatic.totalSupply()
+        const bonusBefore = await betCakeFarm.callStatic.bonus()
+        const totalRewardShareBefore = await betCakeFarm.callStatic._shareTotal()
+        const totalEarnedBonusBefore = await betCakeFarm.callStatic.earned(betCakeFarm.address)
+        const betCakeFarmStakeBalanceBefore = (await masterChef.callStatic.userInfo(poolId, betCakeFarm.address))[0]
+        const betCakeFarmEarnedRewardsBefore = await masterChef.callStatic.pendingCake(poolId, betCakeFarm.address)
+        // Should have accrued reward
+        expect(betCakeFarmEarnedRewardsBefore).to.be.gt(0)
+        // Assume no one else staking: user reward should be the same as total rewards
+        expect(totalRewardShareBefore).to.equal(userRewardShareBefore)
+        // Should not earn any bonus before cook
+        expect(totalEarnedBonusBefore).to.equal(0)
+
+        // User's reward locked as MasterChef reward should not be zero
+        const userEarnedLockedRewardsBefore = await betCakeFarm.callStatic.earnedLocked(userAddr)
+        expect(userEarnedLockedRewardsBefore).to.be.gt(0)
+
+        const tx = await betCakeFarm.connect(operator).cook(minBCNTAmountConverted)
+
+        // Operator should receive rewards
+        const operatorRewardAmountAfter = await bcnt.callStatic.balanceOf(operatorAddress)
+        expect(operatorRewardAmountAfter).to.be.gt(operatorRewardAmountBefore)
+        // expect(tx).to.emit(betCakeFarm, "Cook").withArgs(betCakeFarmEarnedRewardsBefore)
+        const betCakeFarmRewardBalanceAfter = await bcnt.callStatic.balanceOf(betCakeFarm.address)
+        // Should send away all reward
+        expect(betCakeFarmRewardBalanceAfter).to.equal(0)
+
+        // Should not change total supply
+        const totalSupplyAfter = await betCakeFarm.callStatic.totalSupply()
+        expect(totalSupplyAfter).to.equal(totalSupplyBefore)
+        // Should not change bonus amount
+        const bonusAfter = await betCakeFarm.callStatic.bonus()
+        expect(bonusAfter).to.equal(bonusBefore)
+        // Should not change Bet balance 
+        const betCakeFarmStakeBalanceAfter = (await masterChef.callStatic.userInfo(poolId, betCakeFarm.address))[0]
+        expect(betCakeFarmStakeBalanceAfter).to.equal(betCakeFarmStakeBalanceBefore)
+        const totalEarnedBonusAfter = await betCakeFarm.callStatic.earned(betCakeFarm.address)
+        // Should not earn any bonus after cook
+        expect(totalEarnedBonusAfter).to.equal(0)
+
+        // User's reward locked as MasterChef reward should be zero after cook
+        const userEarnedLockedRewardsAfter = await betCakeFarm.callStatic.earnedLocked(userAddr)
+        expect(userEarnedLockedRewardsAfter).to.equal(0)
+
+        const cookedRewardAmount = betCakeFarmRewardBalanceBefore.sub(betCakeFarmRewardBalanceAfter).add(betCakeFarmEarnedRewardsBefore)
+        const rewards = ethers.utils.formatUnits(
+            cookedRewardAmount,
+            18
+        )
+        console.log(`Cook ${rewards} rewards`)
+    })
+
+    it("Should transfer stake to TempStakeManager when staking in Lock state", async () => {
+        const userTempStkCakeFarmBalanceBefore = await tempStakeManager.callStatic.balanceOf(userAddr)
+        expect(userTempStkCakeFarmBalanceBefore).to.equal(0)
+        const betCakeFarmStakeBalanceBefore = (await masterChef.callStatic.userInfo(poolId, betCakeFarm.address))[0]
+        const tempStkMgrCakeFarmStakeBalanceBefore = (await masterChef.callStatic.userInfo(poolId, tempStakeManager.address))[0]
+
+        const stakeAmount = ethers.utils.parseUnits('100')
+        await token1.connect(user).approve(betCakeFarm.address, stakeAmount)
+
+        const isToken0 = false
+        const tx = await betCakeFarm.connect(user).stake(isToken0, stakeAmount, minReceivedToken0Amount, minReceivedToken0Amount, minReceivedToken1Amount)
+        const receipt = await tx.wait()
+
+        const userTempStkCakeFarmBalanceAfter = await tempStakeManager.callStatic.balanceOf(userAddr)
+        const betCakeFarmStakeBalanceAfter = (await masterChef.callStatic.userInfo(poolId, betCakeFarm.address))[0]
+        // Bet stake balance should remain the same
+        expect(betCakeFarmStakeBalanceAfter).to.equal(betCakeFarmStakeBalanceBefore)
+        const tempStkMgrCakeFarmStakeBalanceAfter = (await masterChef.callStatic.userInfo(poolId, tempStakeManager.address))[0]
+        const stakedAmount = tempStkMgrCakeFarmStakeBalanceAfter.sub(tempStkMgrCakeFarmStakeBalanceBefore)
+        expect(tempStkMgrCakeFarmStakeBalanceAfter.sub(tempStkMgrCakeFarmStakeBalanceBefore)).to.equal(stakedAmount)
+        expect(userTempStkCakeFarmBalanceAfter.sub(userTempStkCakeFarmBalanceBefore)).to.equal(stakedAmount)
+        expect(stakedAmount).to.be.gt(0)
+        expect(tx).to.emit(tempStakeManager, "Staked").withArgs(userAddr, stakedAmount)
+
+        const staked = ethers.utils.formatUnits(
+            stakedAmount,
+            18
+        )
+        console.log(`Staked ${staked} LP into TempStakeManager`)
+    })
+
+    it("Should serve", async () => {
+        const userEarnedBonusBefore = await betCakeFarm.callStatic.earned(userAddr)
+
+        const totalSupplyBefore = await betCakeFarm.callStatic.totalSupply()
+        const totalEarnedBonusBefore = await betCakeFarm.callStatic.earned(betCakeFarm.address)
+        const betCakeFarmStakeBalanceBefore = (await masterChef.callStatic.userInfo(poolId, betCakeFarm.address))[0]
+        // Should not earn any bonus before first serve
+        expect(totalEarnedBonusBefore).to.equal(0)
+        const betCakeFarmRewardBalanceBefore = await bcnt.callStatic.balanceOf(betCakeFarm.address)
+        // Should have no reward before serve
+        expect(betCakeFarmRewardBalanceBefore).to.equal(0)
+        const periodBefore = await betCakeFarm.callStatic.period()
+        expect(periodBefore).to.equal(1)
+
+        numFFBlocks = 1000
+        await mineBlocks(numFFBlocks)
+
+        const returnedRewardAmount = ethers.utils.parseUnits('1000')
+        // Transfer rewards to operator because operator does not have enough rewards to serve
+        await bcnt.connect(owner).transfer(operatorAddress, returnedRewardAmount)
+        // operator approve Bet contract
+        await bcnt.connect(operator).approve(betCakeFarm.address, returnedRewardAmount)
+        const tx = await betCakeFarm.connect(operator).serve(returnedRewardAmount)
+
+        const periodAfter = await betCakeFarm.callStatic.period()
+        expect(periodAfter).to.equal(2)
+
+        // User should earn bonus
+        const userEarnedBonusAfter = await betCakeFarm.callStatic.earned(userAddr)
+
+        // Should not change total supply
+        const totalSupplyAfter = await betCakeFarm.callStatic.totalSupply()
+        expect(totalSupplyAfter).to.equal(totalSupplyBefore)
+        // Should update bonus amount 
+        const bonusAfter = await betCakeFarm.callStatic.bonus()
+        expect(tx).to.emit(betCakeFarm, "Serve").withArgs(returnedRewardAmount)
+        // Should not change Bet balance 
+        const betCakeFarmStakeBalanceAfter = (await masterChef.callStatic.userInfo(poolId, betCakeFarm.address))[0]
+        expect(betCakeFarmStakeBalanceAfter).to.equal(betCakeFarmStakeBalanceBefore)
+        const betCakeFarmRewardBalanceAfter = await bcnt.callStatic.balanceOf(betCakeFarm.address)
+        expect(betCakeFarmRewardBalanceAfter).to.equal(returnedRewardAmount)
+        // Should match bonus and reward balance
+        expect(betCakeFarmRewardBalanceAfter).to.equal(bonusAfter)
+        
+        const bonusAmount = bonusAfter
+        const bonus = ethers.utils.formatUnits(
+            bonusAmount,
+            18
+        )
+        console.log(`Serve ${bonus} bonus`)
+        const earnedBonusBefroe = ethers.utils.formatUnits(
+            userEarnedBonusBefore,
+            18
+        )
+        const earnedBonusAfter = ethers.utils.formatUnits(
+            userEarnedBonusAfter,
+            18
+        )
+        console.log(`User bonus before/after: ${earnedBonusBefroe}/${earnedBonusAfter}`)
+    })
+
+    it("Should transfer stake back to Bet after Lock state", async () => {
+        const userTempStkCakeFarmBalanceBefore = await tempStakeManager.callStatic.balanceOf(userAddr)
+        const userStakeBalanceBefore = await betCakeFarm.callStatic.balanceOf(userAddr)
+        const betCakeFarmStakeBalanceBefore = (await masterChef.callStatic.userInfo(poolId, betCakeFarm.address))[0]
+        const tempStkMgrCakeFarmStakeBalanceBefore = (await masterChef.callStatic.userInfo(poolId, tempStakeManager.address))[0]
+
+        // Check user is in TempStakeManager staker list
+        const numStakers = 1
+        const stakerListBefore = await tempStakeManager.callStatic.getAllStakers()
+        expect(stakerListBefore.length).to.equal(numStakers)
+        expect(stakerListBefore[0]).to.equal(userAddr)
+
+        const stakerIndex = 0
+        const tx = await betCakeFarm.connect(operator).transferStake(
+            stakerIndex,
+            [
+                minReceivedToken0Amount,
+                minReceivedToken0Amount,
+                minReceivedToken0Amount,
+                minReceivedToken1Amount
+            ]
+        )
+        const receipt = await tx.wait()
+
+        const stakerListAfter = await tempStakeManager.callStatic.getAllStakers()
+        expect(stakerListAfter.length).to.equal(0)
+
+        const userTempStkCakeFarmBalanceAfter = await tempStakeManager.callStatic.balanceOf(userAddr)
+        expect(userTempStkCakeFarmBalanceAfter).to.equal(0)
+        const userStakeBalanceAfter = await betCakeFarm.callStatic.balanceOf(userAddr)
+        const betCakeFarmStakeBalanceAfter = (await masterChef.callStatic.userInfo(poolId, betCakeFarm.address))[0]
+        const tempStkMgrCakeFarmStakeBalanceAfter = (await masterChef.callStatic.userInfo(poolId, tempStakeManager.address))[0]
+        expect(tempStkMgrCakeFarmStakeBalanceAfter).to.equal(0)
+        // Stake should be transferred from TempStakeManager to Bet, along with stake converted from reward
+        expect(betCakeFarmStakeBalanceAfter.sub(betCakeFarmStakeBalanceBefore)).to.be.gte(tempStkMgrCakeFarmStakeBalanceBefore.sub(tempStkMgrCakeFarmStakeBalanceAfter))
+        expect(userStakeBalanceAfter.sub(userStakeBalanceBefore)).to.be.gte(userTempStkCakeFarmBalanceBefore.sub(userTempStkCakeFarmBalanceAfter))
+        const transferredStakeAmount = userTempStkCakeFarmBalanceBefore.sub(userTempStkCakeFarmBalanceAfter)
+        expect(tx).to.emit(tempStakeManager, "Withdrawn").withArgs(userAddr, transferredStakeAmount)
+        const convertedLPAmount = betCakeFarmStakeBalanceAfter.sub(betCakeFarmStakeBalanceBefore).sub(transferredStakeAmount)
+        expect(tx).to.emit(tempStakeManager, "ConvertedLP").withArgs(userAddr, convertedLPAmount)
+
+
+        const transferredStake = ethers.utils.formatUnits(
+            transferredStakeAmount,
+            18
+        )
+        const converted = ethers.utils.formatUnits(
+            convertedLPAmount,
+            18
+        )
+        console.log(`Transfer ${transferredStake} LP from TempStakeManager to Bet`)
+        console.log(`Transfer along with ${converted} LP converted from reward`)
+    })
+
+    it("Should withdraw and convert to Token0", async () => {
+        const userToken0BalanceBefore = await token0.callStatic.balanceOf(userAddr)
+        const userStakeBalanceBefore = await betCakeFarm.callStatic.balanceOf(userAddr)
+
+        const betCakeFarmStakeBalanceBefore = (await masterChef.callStatic.userInfo(poolId, betCakeFarm.address))[0]
+
+        const withdrawAmount = ethers.utils.parseUnits('5')
+
+        const token0Percentage = 100
+        const tx = await betCakeFarm.connect(user).withdraw(minReceivedToken0Amount, minReceivedToken1Amount, token0Percentage, withdrawAmount)
+        const receipt = await tx.wait()
+
+        const userToken0BalanceAfter = await token0.callStatic.balanceOf(userAddr)
+        // Should receive withdrawal
+        expect(userToken0BalanceAfter).to.be.gt(userToken0BalanceBefore)
+        const userStakeBalanceAfter = await betCakeFarm.callStatic.balanceOf(userAddr)
+        // Should match balance difference and withdraw amount
+        expect(userStakeBalanceBefore.sub(userStakeBalanceAfter)).to.equal(withdrawAmount)
+
+        const betCakeFarmStakeBalanceAfter = (await masterChef.callStatic.userInfo(poolId, betCakeFarm.address))[0]
+        // Should match Bet balance difference and user withdraw amount
+        expect(betCakeFarmStakeBalanceBefore.sub(betCakeFarmStakeBalanceAfter)).to.equal(withdrawAmount)
+
+        const withdrew = ethers.utils.formatUnits(
+            withdrawAmount,
+            18
+        )
+        console.log(`Withdrew ${withdrew} LP`)
+        const receivedToken0 = ethers.utils.formatUnits(
+            userToken0BalanceAfter.sub(userToken0BalanceBefore),
+            18
+        )
+        console.log(`Converted to ${receivedToken0} Token0`)
+    })
+
+    it("Should withdraw with LP Token", async () => {
+        const betCakeFarmStakeBalanceBefore = (await masterChef.callStatic.userInfo(poolId, betCakeFarm.address))[0]
+
+        // LP token amount
+        const withdrawAmount = ethers.utils.parseUnits('1')
+
+        const tx = await betCakeFarm.connect(user).withdrawWithLP(withdrawAmount)
+        const receipt = await tx.wait()
+
+        const betCakeFarmStakeBalanceAfter = (await masterChef.callStatic.userInfo(poolId, betCakeFarm.address))[0]
+        const withdrawnAmount = betCakeFarmStakeBalanceBefore.sub(betCakeFarmStakeBalanceAfter)
+        expect(withdrawnAmount).to.equal(withdrawAmount)
+
+        const withdrew = ethers.utils.formatUnits(
+            withdrawnAmount,
+            18
+        )
+        console.log(`Withdrew ${withdrew} LP`)
+    })
+
+    it("Should withdraw and convert to native token", async () => {
+        if (token0.address == wbnb.address || token1.address == wbnb.address) {
+            const userNativeTokenBalanceBefore = await user.getBalance()
+            const userStakeBalanceBefore = await betCakeFarm.callStatic.balanceOf(userAddr)
+
+            const betCakeFarmStakeBalanceBefore = (await masterChef.callStatic.userInfo(poolId, betCakeFarm.address))[0]
+
+            const withdrawAmount = ethers.utils.parseUnits('1')
+
+            const tx = await betCakeFarm.connect(user).withdrawWithNative(minReceivedToken0Amount, minReceivedToken1Amount, withdrawAmount)
+            const receipt = await tx.wait()
+
+            const userNativeTokenBalanceAfter = await user.getBalance()
+            // Should receive withdrawal
+            expect(userNativeTokenBalanceAfter).to.be.gt(userNativeTokenBalanceBefore)
+            const userStakeBalanceAfter = await betCakeFarm.callStatic.balanceOf(userAddr)
+            // Should match balance difference and withdraw amount
+            expect(userStakeBalanceBefore.sub(userStakeBalanceAfter)).to.equal(withdrawAmount)
+
+            const betCakeFarmStakeBalanceAfter = (await masterChef.callStatic.userInfo(poolId, betCakeFarm.address))[0]
+            // Should match Bet balance difference and user withdraw amount
+            expect(betCakeFarmStakeBalanceBefore.sub(betCakeFarmStakeBalanceAfter)).to.equal(withdrawAmount)
+
+            const withdrew = ethers.utils.formatUnits(
+                withdrawAmount,
+                18
+            )
+            console.log(`Withdrew ${withdrew} LP`)
+            const receivedNativeToken = ethers.utils.formatUnits(
+                userNativeTokenBalanceAfter.sub(userNativeTokenBalanceBefore),
+                18
+            )
+            console.log(`Converted to ${receivedNativeToken} native token`)
+        } else {
+            console.log("Skipped withdraw native token test")
+        }
+    })
+
+    it("Should getReward and user receives all bonus he deserves", async () => {
+        // Fast froward some blocks to accrue reward to test `getMasterChefReward`
+        numFFBlocks = 10
+        await mineBlocks(numFFBlocks)
+
+        const userRewardBalanceBefore = await bcnt.callStatic.balanceOf(userAddr)
+        const userStakeBalanceBefore = await betCakeFarm.callStatic.balanceOf(userAddr)
+        const userRewardShareBefore = await betCakeFarm.callStatic._share(userAddr)
+        const userEarnedBonusBefore = await betCakeFarm.callStatic.earned(userAddr)
+
+        const totalRewardShareBefore = await betCakeFarm.callStatic._shareTotal()
+        const totalEarnedBonusBefore = await betCakeFarm.callStatic.earned(betCakeFarm.address)
+        const bonusBefore = await betCakeFarm.callStatic.bonus()
+        // Assume no one else staking: user reward should be the same as total rewards
+        expect(userEarnedBonusBefore).to.equal(totalEarnedBonusBefore)
+        expect(totalEarnedBonusBefore).to.equal(bonusBefore)
+        const betCakeFarmStakeBalanceBefore = (await masterChef.callStatic.userInfo(poolId, betCakeFarm.address))[0]
+        const betCakeFarmEarnedRewardsBefore = (await masterChef.callStatic.pendingCake(poolId, betCakeFarm.address)).add(await cake.callStatic.balanceOf(betCakeFarm.address))
+
+        const getMasterChefReward = true
+        const tx = await betCakeFarm.connect(user)["getReward(uint256,bool)"](minBCNTAmountConverted, getMasterChefReward)
+        const receipt = await tx.wait()
+
+        const userRewardBalanceAfter = await bcnt.callStatic.balanceOf(userAddr)
+        // Should receive reward
+        expect(userRewardBalanceAfter).to.be.gt(userRewardBalanceBefore)
+        const userStakeBalanceAfter = await betCakeFarm.callStatic.balanceOf(userAddr)
+        // Should not change user stake balance
+        expect(userStakeBalanceAfter).to.equal(userStakeBalanceBefore)
+
+        const userRewardShareAfter = await betCakeFarm.callStatic._share(userAddr)
+        // Should have no rewards left
+        expect(userRewardShareAfter).to.equal(0)
+        const bonusAfter = await betCakeFarm.callStatic.bonus()
+        // Assume no one else staking: should have no rewards left
+        expect(bonusAfter).to.equal(0)
+        let receivedBonusAmount = bonusBefore.sub(bonusAfter)
+        // Should receive bonus
+        expect(receivedBonusAmount).to.be.gt(0)
+        expect(receivedBonusAmount).to.equal(bonusBefore.mul(userRewardShareBefore).div(totalRewardShareBefore))
+        if (getMasterChefReward && betCakeFarmEarnedRewardsBefore.gt(0)) {
+            expect(tx).to.emit(betCakeFarm, "MasterChefReward")
+            const masterChefRewardEvents = parseLogsByName(betCakeFarm, "MasterChefReward", receipt.logs)
+            const actualMasterChefReward = masterChefRewardEvents[0].args.amount
+            const expectedMasterChefReward = betCakeFarmEarnedRewardsBefore.mul(userRewardShareBefore).div(totalRewardShareBefore)
+            expect(actualMasterChefReward).to.be.gte(expectedMasterChefReward)
+            // Diff should be less than 1%
+            console.log(`MasterChef reward amount diff: ${actualMasterChefReward.sub(expectedMasterChefReward)}`)
+            expect(actualMasterChefReward.sub(expectedMasterChefReward)).to.be.lt(actualMasterChefReward.div(100))
+            const rewardPaidEvents = parseLogsByName(betCakeFarm, "RewardPaid", receipt.logs)
+            const actualRewardPaid = rewardPaidEvents[0].args.reward
+            // Actual received should be less than received Bonus amount plus MasterChef reward amount
+            // because it needs to swap MasterChef reward for BCNT
+            expect(actualRewardPaid).to.be.lt(receivedBonusAmount.add(actualMasterChefReward))
+            receivedBonusAmount = actualRewardPaid
+        } else {
+            expect(tx).to.emit(betCakeFarm, "RewardPaid").withArgs(userAddr, receivedBonusAmount)
+        }
+
+        const betCakeFarmStakeBalanceAfter = (await masterChef.callStatic.userInfo(poolId, betCakeFarm.address))[0]
+        // Should not change total stake balance
+        expect(betCakeFarmStakeBalanceAfter).to.equal(betCakeFarmStakeBalanceBefore)
+
+        const receivedBonus = ethers.utils.formatUnits(
+            receivedBonusAmount,
+            18
+        )
+        console.log(`Get ${receivedBonus} bonus`)
+    })
+
+    it("Should fail to getReward in same period", async () => {
+        const getMasterChefReward = true
+        await expect(
+            betCakeFarm.connect(user)["getReward(uint256,bool)"](
+                minBCNTAmountConverted, getMasterChefReward)
+        ).to.be.revertedWith("Already getReward in this period")
+    })
+
+    it("Should cook", async () => {
+        numFFBlocks = 1000
+        await mineBlocks(numFFBlocks)
+
+        const betCakeFarmRewardBalanceBefore = await bcnt.callStatic.balanceOf(betCakeFarm.address)
+        const betCakeFarmEarnedRewardsBefore = await masterChef.callStatic.pendingCake(poolId, betCakeFarm.address)
+        // Should have accrued reward
+        expect(betCakeFarmEarnedRewardsBefore).to.be.gt(0)
+
+        const tx = await betCakeFarm.connect(operator).cook(minBCNTAmountConverted)
+
+        const betCakeFarmRewardBalanceAfter = await bcnt.callStatic.balanceOf(betCakeFarm.address)
+
+        const cookedRewardAmount = betCakeFarmRewardBalanceBefore.sub(betCakeFarmRewardBalanceAfter).add(betCakeFarmEarnedRewardsBefore)
+        const rewards = ethers.utils.formatUnits(
+            cookedRewardAmount,
+            18
+        )
+        console.log(`Cook ${rewards} rewards`)
+    })
+
+    it("Should serve", async () => {
+        const userEarnedBonusBefore = await betCakeFarm.callStatic.earned(userAddr)
+
+        const totalSupplyBefore = await betCakeFarm.callStatic.totalSupply()
+        const totalEarnedBonusBefore = await betCakeFarm.callStatic.earned(betCakeFarm.address)
+        const betCakeFarmStakeBalanceBefore = (await masterChef.callStatic.userInfo(poolId, betCakeFarm.address))[0]
+        // Should not earn any bonus before first serve
+        expect(totalEarnedBonusBefore).to.equal(0)
+        const betCakeFarmRewardBalanceBefore = await bcnt.callStatic.balanceOf(betCakeFarm.address)
+        // Should have no reward before serve
+        expect(betCakeFarmRewardBalanceBefore).to.equal(0)
+        const periodBefore = await betCakeFarm.callStatic.period()
+        expect(periodBefore).to.equal(2)
+
+        numFFBlocks = 5000
+        await mineBlocks(numFFBlocks)
+
+        const returnedRewardAmount = ethers.utils.parseUnits('1000')
+        // Transfer rewards to operator because operator does not have enough rewards to serve
+        await bcnt.connect(owner).transfer(operatorAddress, returnedRewardAmount)
+        // operator approve Bet contract
+        await bcnt.connect(operator).approve(betCakeFarm.address, returnedRewardAmount)
+        const tx = await betCakeFarm.connect(operator).serve(returnedRewardAmount)
+
+        const periodAfter = await betCakeFarm.callStatic.period()
+        expect(periodAfter).to.equal(3)
+
+        // User should earn bonus
+        const userEarnedBonusAfter = await betCakeFarm.callStatic.earned(userAddr)
+
+        // Should not change total supply
+        const totalSupplyAfter = await betCakeFarm.callStatic.totalSupply()
+        expect(totalSupplyAfter).to.equal(totalSupplyBefore)
+        // Should update bonus amount 
+        const bonusAfter = await betCakeFarm.callStatic.bonus()
+        expect(tx).to.emit(betCakeFarm, "Serve").withArgs(returnedRewardAmount)
+        // Should not change Bet balance 
+        const betCakeFarmStakeBalanceAfter = (await masterChef.callStatic.userInfo(poolId, betCakeFarm.address))[0]
+        expect(betCakeFarmStakeBalanceAfter).to.equal(betCakeFarmStakeBalanceBefore)
+        const betCakeFarmRewardBalanceAfter = await bcnt.callStatic.balanceOf(betCakeFarm.address)
+        expect(betCakeFarmRewardBalanceAfter).to.equal(returnedRewardAmount)
+        // Should match bonus and reward balance
+        expect(betCakeFarmRewardBalanceAfter).to.equal(bonusAfter)
+        
+        const bonusAmount = bonusAfter
+        const bonus = ethers.utils.formatUnits(
+            bonusAmount,
+            18
+        )
+        console.log(`Serve ${bonus} bonus`)
+        const earnedBonusBefroe = ethers.utils.formatUnits(
+            userEarnedBonusBefore,
+            18
+        )
+        const earnedBonusAfter = ethers.utils.formatUnits(
+            userEarnedBonusAfter,
+            18
+        )
+        console.log(`User bonus before/after: ${earnedBonusBefroe}/${earnedBonusAfter}`)
+        console.log("User bonus before would be zero because he already trigger `getReward`")
+    })
+
+    it("Should cook again and enter Lock state", async () => {
+        numFFBlocks = 1000
+        await mineBlocks(numFFBlocks)
+
+        const betCakeFarmRewardBalanceBefore = await bcnt.callStatic.balanceOf(betCakeFarm.address)
+        const betCakeFarmEarnedRewardsBefore = await masterChef.callStatic.pendingCake(poolId, betCakeFarm.address)
+        // Should have accrued reward
+        expect(betCakeFarmEarnedRewardsBefore).to.be.gt(0)
+
+        const tx = await betCakeFarm.connect(operator).cook(minBCNTAmountConverted)
+
+        const betCakeFarmRewardBalanceAfter = await bcnt.callStatic.balanceOf(betCakeFarm.address)
+
+        const cookedRewardAmount = betCakeFarmRewardBalanceBefore.sub(betCakeFarmRewardBalanceAfter).add(betCakeFarmEarnedRewardsBefore)
+        const rewards = ethers.utils.formatUnits(
+            cookedRewardAmount,
+            18
+        )
+        console.log(`Cook ${rewards} rewards`)
+    })
+
+    it("Should exit and convert to Token1 but user only get part of bonus", async () => {
+        const frontRewardsAmount = ethers.utils.parseUnits("10000")
+        // Transfer rewards to liquidityProvider because liquidityProvider does not have enough rewards to front the withdraw payment
+        await bcnt.connect(owner).transfer(liquidityProviderAddress, frontRewardsAmount)
+
+        const userToken1BalanceBefore = await token1.callStatic.balanceOf(userAddr)
+        const userStakeBefore = await betCakeFarm.callStatic.balanceOf(userAddr)
+        const userRewardShareBefore = await betCakeFarm.callStatic._share(userAddr)
+        const userEarnedBonusBefore = await betCakeFarm.callStatic.earned(userAddr)
+
+        const totalRewardShareBefore = await betCakeFarm.callStatic._shareTotal()
+        const totalEarnedBonusBefore = await betCakeFarm.callStatic.earned(betCakeFarm.address)
+        const bonusBefore = await betCakeFarm.callStatic.bonus()
+        // Assume no one else staking: user reward should be the same as total rewards
+        expect(userEarnedBonusBefore).to.equal(totalEarnedBonusBefore)
+        expect(totalEarnedBonusBefore).to.equal(bonusBefore)
+
+        // Liquidity provider approve Bet contract to transfer rewards from him to front the withdraw payment
+        await bcnt.connect(liquidityProvider).approve(betCakeFarm.address, MAX_INT)
+        const token0Percentage = 0
+        const tx = await betCakeFarm.connect(user).exit(minReceivedToken0Amount, minReceivedToken0Amount, minReceivedToken1Amount, token0Percentage)
+        const receipt = await tx.wait()
+        // Liquidity provider clear allowance
+        await bcnt.connect(liquidityProvider).approve(betCakeFarm.address, 0)
+
+        const userToken1alanceAfter = await token1.callStatic.balanceOf(userAddr)
+        // Should receive withdrawal
+        expect(userToken1alanceAfter).to.be.gt(userToken1BalanceBefore)
+        const userStakeBalanceAfter = await betCakeFarm.callStatic.balanceOf(userAddr)
+        // Should be no user balance left
+        expect(userStakeBalanceAfter).to.equal(0)
+
+        const userRewardShareAfter = await betCakeFarm.callStatic._share(userAddr)
+        // Should be no user earned rewards left
+        expect(userRewardShareAfter).to.equal(0)
+        const totalRewardShareAfter = await betCakeFarm.callStatic._shareTotal()
+        const bonusAfter = await betCakeFarm.callStatic.bonus()
+        // Should be rewards left since part of bonus are given to operator
+        expect(totalRewardShareAfter).to.be.gt(0)
+        expect(bonusAfter).to.be.gt(0)
+        const receivedBonusAmount = bonusBefore.sub(bonusAfter)
+        // Should receive bonus tokens
+        expect(receivedBonusAmount).to.be.gt(0)
+        expect(tx).to.emit(betCakeFarm, "RewardPaid").withArgs(userAddr, receivedBonusAmount)
+        const expectedEarnedWithdrawn = userRewardShareBefore
+        // User should only receive part of bonus since he withdraw in Lock state
+        const expectedBonusAmountReceived = bonusBefore.mul(expectedEarnedWithdrawn).mul(100 - penaltyPercentage).div(100).div(totalRewardShareBefore)
+        // Should match actual received bonus amount and expected received bonus Amount
+        // It can not be exact match because rewards are accrueing every seconds and time is different
+        // the moment you query it and the moment transaction executes 
+        const bonusAmountDiff = (
+            receivedBonusAmount.gt(expectedBonusAmountReceived) ?
+            receivedBonusAmount.sub(expectedBonusAmountReceived) : expectedBonusAmountReceived.sub(receivedBonusAmount)
+        )
+        console.log(`Bonus amount diff: ${bonusAmountDiff}`)
+        expect(bonusAmountDiff).to.be.lt(10**6)
+        // Operator should receive the other part of bonus
+        const liquidityProviderRewardShareAfter = await betCakeFarm.callStatic._share(liquidityProviderAddress)
+        expect(liquidityProviderRewardShareAfter).to.equal(totalRewardShareAfter)
+        const betCakeFarmStakeBalanceAfter = (await masterChef.callStatic.userInfo(poolId, betCakeFarm.address))[0]
+        // Assume no one else staking: should be no Bet balance left
+        expect(betCakeFarmStakeBalanceAfter).to.equal(0)
+
+        const stakeAmount = ethers.utils.formatUnits(
+            userStakeBefore,
+            18
+        )
+        const receivedBonus = ethers.utils.formatUnits(
+            receivedBonusAmount,
+            18
+        )
+        console.log(`Exit with ${stakeAmount} LP and get ${receivedBonus} reward`)
+        const receivedToken1 = ethers.utils.formatUnits(
+            userToken1alanceAfter.sub(userToken1BalanceBefore),
+            18
+        )
+        console.log(`Converted them to ${receivedToken1} Token1`)
+    })
+
+    it("Should transfer stake to TempStakeManager when staking in Lock state", async () => {
+        const userTempStkCakeFarmBalanceBefore = await tempStakeManager.callStatic.balanceOf(userAddr)
+        expect(userTempStkCakeFarmBalanceBefore).to.equal(0)
+        const betCakeFarmStakeBalanceBefore = (await masterChef.callStatic.userInfo(poolId, betCakeFarm.address))[0]
+        const tempStkMgrCakeFarmStakeBalanceBefore = (await masterChef.callStatic.userInfo(poolId, tempStakeManager.address))[0]
+
+        const stakeAmount = ethers.utils.parseUnits('100')
+        await token1.connect(user).approve(betCakeFarm.address, stakeAmount)
+
+        const isToken0 = false
+        const tx = await betCakeFarm.connect(user).stake(isToken0, stakeAmount, minReceivedToken0Amount, minReceivedToken0Amount, minReceivedToken1Amount)
+        const receipt = await tx.wait()
+
+        const userTempStkCakeFarmBalanceAfter = await tempStakeManager.callStatic.balanceOf(userAddr)
+        const betCakeFarmStakeBalanceAfter = (await masterChef.callStatic.userInfo(poolId, betCakeFarm.address))[0]
+        // Bet stake balance should remain the same
+        expect(betCakeFarmStakeBalanceAfter).to.equal(betCakeFarmStakeBalanceBefore)
+        const tempStkMgrCakeFarmStakeBalanceAfter = (await masterChef.callStatic.userInfo(poolId, tempStakeManager.address))[0]
+        const stakedAmount = tempStkMgrCakeFarmStakeBalanceAfter.sub(tempStkMgrCakeFarmStakeBalanceBefore)
+        expect(tempStkMgrCakeFarmStakeBalanceAfter.sub(tempStkMgrCakeFarmStakeBalanceBefore)).to.equal(stakedAmount)
+        expect(userTempStkCakeFarmBalanceAfter.sub(userTempStkCakeFarmBalanceBefore)).to.equal(stakedAmount)
+        expect(stakedAmount).to.be.gt(0)
+        expect(tx).to.emit(tempStakeManager, "Staked").withArgs(userAddr, stakedAmount)
+
+        const staked = ethers.utils.formatUnits(
+            stakedAmount,
+            18
+        )
+        console.log(`Staked ${staked} LP into TempStakeManager`)
+    })
+
+    it("Should abort user from TempStakeManager", async () => {
+        numFFBlocks = 1000
+        await mineBlocks(numFFBlocks)
+
+        const userRewardBalanceBefore = await bcnt.callStatic.balanceOf(userAddr)
+        const userMWLPBalanceBefore = await lpToken.callStatic.balanceOf(userAddr)
+        const userTempStkEarnedBefore = await tempStakeManager.callStatic.earned(userAddr)
+        const userTempStkCakeFarmBalanceBefore = await tempStakeManager.callStatic.balanceOf(userAddr)
+        expect(userTempStkCakeFarmBalanceBefore).to.be.gt(0)
+        const betCakeFarmStakeBalanceBefore = (await masterChef.callStatic.userInfo(poolId, betCakeFarm.address))[0]
+
+        const tx = await betCakeFarm.connect(operator).abortFromTempStakeManager([userAddr], [minBCNTAmountConverted])
+        const receipt = await tx.wait()
+
+        const userRewardBalanceAfter = await bcnt.callStatic.balanceOf(userAddr)
+        const userMWLPBalanceAfter = await lpToken.callStatic.balanceOf(userAddr)
+        const userTempStkCakeFarmBalanceAfter = await tempStakeManager.callStatic.balanceOf(userAddr)
+        expect(userTempStkCakeFarmBalanceAfter).to.equal(0)
+        const returnedLPAmount = userMWLPBalanceAfter.sub(userMWLPBalanceBefore)
+        expect(returnedLPAmount).to.equal(userTempStkCakeFarmBalanceBefore.sub(userTempStkCakeFarmBalanceAfter))
+        const betCakeFarmStakeBalanceAfter = (await masterChef.callStatic.userInfo(poolId, betCakeFarm.address))[0]
+        // Bet stake balance should remain the same
+        expect(betCakeFarmStakeBalanceAfter).to.equal(betCakeFarmStakeBalanceBefore)
+        expect(userTempStkCakeFarmBalanceAfter).to.equal(0)
+        const userEarnedRewardAmount = userRewardBalanceAfter.sub(userRewardBalanceBefore)
+        expect(userEarnedRewardAmount).to.be.gte(userTempStkEarnedBefore)
+        expect(tx).to.emit(tempStakeManager, "Abort").withArgs(userAddr, userTempStkCakeFarmBalanceBefore)
+        // expect(tx).to.emit(tempStakeManager, "RewardPaid").withArgs(userAddr, userEarnedRewardAmount)
+
+        const returnedLP = ethers.utils.formatUnits(
+            returnedLPAmount,
+            18
+        )
+        console.log(`Returned ${returnedLP} LP`)
+        const earned = ethers.utils.formatUnits(
+            userEarnedRewardAmount,
+            18
+        )
+        console.log(`Earned ${earned} Rewards during staking in TempStakeManager`)
+    })
+
+    it("Should serve", async () => {
+        const userEarnedBonusBefore = await betCakeFarm.callStatic.earned(userAddr)
+
+        const totalSupplyBefore = await betCakeFarm.callStatic.totalSupply()
+        const betCakeFarmRewardBalanceBefore = await bcnt.callStatic.balanceOf(betCakeFarm.address)
+        // Should have no reward before serve
+        expect(betCakeFarmRewardBalanceBefore).to.equal(0)
+
+        const returnedRewardAmount = ethers.utils.parseUnits('10')
+        // Transfer rewards to operator because operator does not have enough rewards to serve
+        await bcnt.connect(owner).transfer(operatorAddress, returnedRewardAmount)
+        // operator approve Bet contract
+        await bcnt.connect(operator).approve(betCakeFarm.address, returnedRewardAmount)
+        const tx = await betCakeFarm.connect(operator).serve(returnedRewardAmount)
+
+        const periodAfter = await betCakeFarm.callStatic.period()
+        expect(periodAfter).to.equal(4)
+
+        // User should earn bonus
+        const userEarnedBonusAfter = await betCakeFarm.callStatic.earned(userAddr)
+
+        // Should not change total supply
+        const totalSupplyAfter = await betCakeFarm.callStatic.totalSupply()
+        expect(totalSupplyAfter).to.equal(totalSupplyBefore)
+        // Should update bonus amount 
+        const bonusAfter = await betCakeFarm.callStatic.bonus()
+        // Should match bonus and reward balance
+        const betCakeFarmRewardBalanceAfter = await bcnt.callStatic.balanceOf(betCakeFarm.address)
+        expect(betCakeFarmRewardBalanceAfter).to.equal(returnedRewardAmount)
+        expect(betCakeFarmRewardBalanceAfter).to.equal(bonusAfter)
+        expect(tx).to.emit(betCakeFarm, "Serve").withArgs(returnedRewardAmount)
+        
+        const bonusAmount = bonusAfter
+        const bonus = ethers.utils.formatUnits(
+            bonusAmount,
+            18
+        )
+        console.log(`Serve ${bonus} bonus`)
+        const earnedBonusBefroe = ethers.utils.formatUnits(
+            userEarnedBonusBefore,
+            18
+        )
+        const earnedBonusAfter = ethers.utils.formatUnits(
+            userEarnedBonusAfter,
+            18
+        )
+        console.log(`User bonus before/after: ${earnedBonusBefroe}/${earnedBonusAfter}`)
+        console.log("User bonus would be zero because he already trigger `exit`")
+    })
+
+    it("Should get bonus for liquidity provider", async () => {
+        const lpRewardBalanceBefore = await bcnt.callStatic.balanceOf(liquidityProviderAddress)
+        const earnedBonusBefore = await betCakeFarm.callStatic.earned(liquidityProviderAddress)
+        expect(earnedBonusBefore).to.be.gt(0)
+        const bonusBefore = await betCakeFarm.callStatic.bonus()
+        expect(bonusBefore).to.be.gt(0)
+
+        await betCakeFarm.connect(liquidityProvider).liquidityProviderGetBonus()
+
+        const earnedBonusAfter = await betCakeFarm.callStatic.earned(liquidityProviderAddress)
+        expect(earnedBonusAfter).to.equal(0)
+        const bonusAfter = await betCakeFarm.callStatic.bonus()
+        expect(bonusAfter).to.equal(0)
+        const lpRewardBalanceAfter = await bcnt.callStatic.balanceOf(liquidityProviderAddress)
+        expect(lpRewardBalanceAfter.sub(lpRewardBalanceBefore)).to.equal(bonusBefore.sub(bonusAfter))
+
+        const receivedBonusAmount = earnedBonusBefore.sub(earnedBonusAfter)
+        const receivedBonus = ethers.utils.formatUnits(
+            receivedBonusAmount,
+            18
+        )
+        console.log(`Liquidity provider get ${receivedBonus} Reward`)
+    })
+})


### PR DESCRIPTION
- `BetCakeFarm` 合約由 `RewardCompoundCakeFarm` 合約修改而來，我在 95d7ea1 複製然後拔掉核心 function 的內容，接著可以看 cf97642 ，裡面會有將核心 function 內容填入 Bet 相關邏輯的改動
- `TempStakeManagerCakeFarm` 和 `TempStakeManager` 基本上一樣，除了在 `abort` 裡多了一個參數
- `BetCakeFarm` 的測試內容也和 `Bet` 差不多